### PR TITLE
Fix: add polling timeouts and sqlite busy timeout

### DIFF
--- a/backend/services/database_service.py
+++ b/backend/services/database_service.py
@@ -47,8 +47,10 @@ class DatabaseService:
     @contextmanager
     def get_connection(self):
         """获取数据库连接的上下文管理器"""
-        conn = sqlite3.connect(self.db_path)
+        conn = sqlite3.connect(self.db_path, timeout=5)
         conn.row_factory = sqlite3.Row  # 返回字典形式的结果
+        # 避免并发写入时频繁触发 database is locked
+        conn.execute("PRAGMA busy_timeout = 5000")
         try:
             yield conn
             conn.commit()

--- a/backend/services/image_service.py
+++ b/backend/services/image_service.py
@@ -270,7 +270,7 @@ class NanoBananaService:
     def _get_result(self, task_id: str) -> Dict[str, Any]:
         """获取任务结果"""
         url = f"{self.api_base}/v1/draw/result"
-        response = self.session.post(url, json={"id": task_id})
+        response = self.session.post(url, json={"id": task_id}, timeout=30)
         response.raise_for_status()
         return response.json()
 
@@ -289,7 +289,12 @@ class NanoBananaService:
             if elapsed > max_wait_time:
                 raise TimeoutError(f"任务等待超时 (超过 {max_wait_time} 秒)")
 
-            result = self._get_result(task_id)
+            try:
+                result = self._get_result(task_id)
+            except requests.exceptions.RequestException as e:
+                logger.warning(f"获取任务结果失败，重试中: {e}")
+                time.sleep(poll_interval)
+                continue
 
             if result.get('code') == 0:
                 data = result.get('data', {})


### PR DESCRIPTION
## Summary
- Add timeout + retry handling for image/video polling result requests
- Set SQLite connection timeout and busy_timeout to reduce lock errors

## Testing
- Not run (logic-only change)
