### PR TITLE
Fix: respect generate_images flag and enable sqlite FK

### DIFF
--- a/backend/services/database_service.py
+++ b/backend/services/database_service.py
@@ -49,6 +49,8 @@ class DatabaseService:
         """获取数据库连接的上下文管理器"""
         conn = sqlite3.connect(self.db_path)
         conn.row_factory = sqlite3.Row  # 返回字典形式的结果
+        # 启用外键约束，确保 ON DELETE CASCADE 生效
+        conn.execute("PRAGMA foreign_keys = ON")
         try:
             yield conn
             conn.commit()

--- a/backend/services/pipeline_service.py
+++ b/backend/services/pipeline_service.py
@@ -111,7 +111,7 @@ class PipelineService:
             tm.send_progress(task_id, 'content', 100, f'✅ {total_pages} 页内容生成完成')
             
             # 阶段 5: 图片生成 - 每5页生成一张配图
-            if self.image_service and self.image_service.is_available() and len(pages) > 0:
+            if generate_images and self.image_service and self.image_service.is_available() and len(pages) > 0:
                 # 计算需要生成配图的页面（每5页一张，至少第1页有图）
                 image_pages = [i for i in range(len(pages)) if i % 5 == 0]
                 


### PR DESCRIPTION
## Summary
- Respect generate_images flag to avoid unwanted image generation
- Enable SQLite foreign_keys pragma to make ON DELETE CASCADE effective

## Testing
- Not run (logic-only change)
