### PR TITLE
test: isolate direct Assembler imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ All notable changes to the Vibe Blog project will be documented in this file.
 ### Changed
 - 🔧 **覆盖率产物治理** — 停止跟踪根目录和前端生成的 coverage 报告，并补充通用忽略规则。
 
+### Fixed
+- 🐛 **Assembler 测试模块隔离** — 直接加载 Assembler 后恢复 `sys.modules` 原始状态，避免测试顺序污染后续生产导入。
+- 🐛 **pytest 配置作用域** — 调整 coverage section 位置，确保 markers、asyncio 和 warning 配置由 pytest 正确读取。
+
+### Tests
+- ✨ **导入顺序回归** — 新增临时 Assembler 模块不残留的回归断言，并验证与 code2prompt 测试的双向执行顺序。
+
 ---
 
 ## 2026-02-27 (PR #100 + Optimizations)

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -19,10 +19,6 @@ addopts =
     --cov-report=json
     --cov-report=lcov
 
-# Coverage thresholds
-[coverage:report]
-fail_under = 55
-
 # Markers for test categorization
 markers =
     unit: Unit tests (fast, no external dependencies)
@@ -39,3 +35,7 @@ asyncio_default_fixture_loop_scope = function
 filterwarnings =
     ignore::DeprecationWarning
     ignore::PendingDeprecationWarning
+
+# Coverage thresholds
+[coverage:report]
+fail_under = 55

--- a/backend/tests/test_assembler_footnotes.py
+++ b/backend/tests/test_assembler_footnotes.py
@@ -34,6 +34,7 @@ _assembler_path = os.path.join(
 _spec = importlib.util.spec_from_file_location(
     'services.blog_generator.agents.assembler', _assembler_path
 )
+_original_assembler = sys.modules.get(_spec.name)
 _assembler_mod = importlib.util.module_from_spec(_spec)
 sys.modules[_spec.name] = _assembler_mod
 _spec.loader.exec_module(_assembler_mod)
@@ -49,7 +50,17 @@ if _original_helpers is not None:
 else:
     sys.modules.pop('services.blog_generator.utils.helpers', None)
 
+if _original_assembler is not None:
+    sys.modules[_spec.name] = _original_assembler
+else:
+    sys.modules.pop(_spec.name, None)
+
 AssemblerAgent = _assembler_mod.AssemblerAgent
+
+
+def test_direct_loader_does_not_leave_assembler_module_cached():
+    """The lightweight import must not affect later production imports."""
+    assert sys.modules.get(_spec.name) is _original_assembler
 
 
 def _make_assembler():


### PR DESCRIPTION
## Summary

Extracted from #111 as a focused test-reliability fix.

- restore the original `sys.modules` entry after directly loading Assembler
- prevent the lightweight test module from shadowing later production imports
- add a regression assertion for exact module-state restoration

Original proposal and implementation credit: @freedomgod. The commit preserves co-author attribution.

## TDD evidence

RED:
- `python -m pytest tests/test_assembler_footnotes.py -q --no-cov`
- 1 failed, 21 passed; failure confirmed the temporary Assembler module remained cached

GREEN:
- focused module: 22 passed
- Assembler then code2prompt: 40 passed
- code2prompt then Assembler: 40 passed

Related to #110. This PR intentionally keeps the existing directory layout and production code unchanged.