### PR TITLE
test: colocate E2E tooling with suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the Vibe Blog project will be documented in this file.
 ## 2026-07-21
 
 ### Changed
+- 🔧 **E2E 工具迁移计划** — 明确将专用测试运行与日志分析脚本归入 `tests/e2e/tools/` 的路径和验证方式。
 - 🔧 **测试文档组织** — 将维护中的测试指南迁移到 `docs/testing/`，删除过时的测试实施总结，并从中英文 README 提供统一入口。
 - 🔧 **Codecov 配置归位** — 将仓库级 Codecov 配置迁移到 `.github/`，修正无效的状态结构并与当前前后端覆盖率门槛对齐。
 - 🔧 **仓库结构演进设计** — 明确技术分层、services 能力细分、统一运行目录与渐进兼容迁移的多 PR 路线。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the Vibe Blog project will be documented in this file.
 
 ### Changed
 - 🔧 **E2E 工具迁移计划** — 明确将专用测试运行与日志分析脚本归入 `tests/e2e/tools/` 的路径和验证方式。
+- 🔧 **E2E 工具归位** — 将测试运行与日志分析脚本迁入 `tests/e2e/tools/`，同步适配后端 uv 项目路径和维护文档。
 - 🔧 **测试文档组织** — 将维护中的测试指南迁移到 `docs/testing/`，删除过时的测试实施总结，并从中英文 README 提供统一入口。
 - 🔧 **Codecov 配置归位** — 将仓库级 Codecov 配置迁移到 `.github/`，修正无效的状态结构并与当前前后端覆盖率门槛对齐。
 - 🔧 **仓库结构演进设计** — 明确技术分层、services 能力细分、统一运行目录与渐进兼容迁移的多 PR 路线。

--- a/docs/plans/2026-07-21-organize-e2e-tools.md
+++ b/docs/plans/2026-07-21-organize-e2e-tools.md
@@ -1,0 +1,39 @@
+# Organize E2E Tools Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Move E2E-only helper scripts out of the repository root tooling directory and colocate them with the E2E suite.
+
+**Architecture:** Place executable helpers in `tests/e2e/tools/` while keeping test cases directly under `tests/e2e/`. Recalculate the repository root from the deeper location, update cross-script and documentation references, and preserve all existing command-line options and output paths.
+
+**Tech Stack:** Bash, Python, pytest, Playwright
+
+---
+
+### Task 1: Relocate E2E tools
+
+**Files:**
+- Move: `scripts/run_e2e.sh` to `tests/e2e/tools/run_e2e.sh`
+- Move: `scripts/analyze_e2e_logs.py` to `tests/e2e/tools/analyze_logs.py`
+- Modify: `tests/e2e/tools/run_e2e.sh`
+
+1. Move both files without changing their behavior.
+2. Update repository-root discovery for the deeper directory.
+3. Update the runner's analyzer path.
+4. Run shell syntax and Python compilation checks.
+
+### Task 2: Update maintained documentation
+
+**Files:**
+- Modify: `docs/testing/README.md`
+- Modify: `CHANGELOG.md`
+
+1. Document the one-command E2E runner and log analyzer paths.
+2. Record the repository organization change.
+3. Search for stale `scripts/` references.
+
+### Task 3: Verify and publish
+
+1. Exercise non-destructive runner argument and service-guard paths.
+2. Run the analyzer against an empty temporary runtime layout.
+3. Review the complete diff, push the branch, and create a focused PR.

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -83,6 +83,14 @@ uv run --project backend playwright install chromium
 
 Linux CI or container environments may use `uv run --project backend playwright install --with-deps chromium` to install required system libraries as well.
 
+Use the repository-provided runner to manage services, execute the selected E2E scope, and analyze logs:
+
+```bash
+bash tests/e2e/tools/run_e2e.sh
+bash tests/e2e/tools/run_e2e.sh --smoke
+bash tests/e2e/tools/run_e2e.sh --test-only
+```
+
 Start both services in one terminal:
 
 ```bash
@@ -104,6 +112,12 @@ RUN_E2E_TESTS=1 uv run --project backend pytest tests/e2e/test_tc01_home_load.py
 ```
 
 E2E screenshots are written to `backend/outputs/e2e_screenshots/` and must not be committed.
+
+Analyze the latest E2E and application logs independently:
+
+```bash
+uv run --project backend python tests/e2e/tools/analyze_logs.py --since 10m
+```
 
 ## CI And Coverage
 

--- a/tests/e2e/tools/analyze_logs.py
+++ b/tests/e2e/tools/analyze_logs.py
@@ -12,9 +12,9 @@ E2E 日志分析器 — vibe-blog-browser-test 日志监控子代理的核心脚
   stdout JSON 格式的分析报告，供主代理解析。
 
 用法：
-  python scripts/analyze_e2e_logs.py                          # 分析最近一次测试
-  python scripts/analyze_e2e_logs.py --task-id <id>           # 分析指定任务
-  python scripts/analyze_e2e_logs.py --since 5m               # 分析最近 5 分钟的日志
+  uv run --project backend python tests/e2e/tools/analyze_logs.py
+  uv run --project backend python tests/e2e/tools/analyze_logs.py --task-id <id>
+  uv run --project backend python tests/e2e/tools/analyze_logs.py --since 5m
 """
 import argparse
 import json
@@ -24,7 +24,7 @@ import sys
 from datetime import datetime, timedelta
 from pathlib import Path
 
-PROJECT_ROOT = Path(__file__).resolve().parent.parent
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
 BACKEND_DIR = PROJECT_ROOT / "backend"
 LOGS_DIR = PROJECT_ROOT / "logs"
 TASK_LOGS_DIR = LOGS_DIR / "blog_tasks"

--- a/tests/e2e/tools/run_e2e.sh
+++ b/tests/e2e/tools/run_e2e.sh
@@ -9,12 +9,12 @@
 #   3. 收集截图和日志到 outputs 目录
 #
 # 用法：
-#   bash scripts/run_e2e.sh              # 完整流程（检查服务 + 跑测试）
-#   bash scripts/run_e2e.sh --restart    # 强制重启服务后跑测试
-#   bash scripts/run_e2e.sh --test-only  # 跳过服务检查，直接跑测试
-#   bash scripts/run_e2e.sh --smoke      # 只跑 smoke 测试（TC-01 + TC-02）
-#   bash scripts/run_e2e.sh --chain      # 全链路闭环测试（TC-16）
-#   bash scripts/run_e2e.sh --headed     # 有头模式（显示浏览器窗口）
+#   bash tests/e2e/tools/run_e2e.sh              # 完整流程（检查服务 + 跑测试）
+#   bash tests/e2e/tools/run_e2e.sh --restart    # 强制重启服务后跑测试
+#   bash tests/e2e/tools/run_e2e.sh --test-only  # 跳过服务检查，直接跑测试
+#   bash tests/e2e/tools/run_e2e.sh --smoke      # 只跑 smoke 测试（TC-01 + TC-02）
+#   bash tests/e2e/tools/run_e2e.sh --chain      # 全链路闭环测试（TC-16）
+#   bash tests/e2e/tools/run_e2e.sh --headed     # 有头模式（显示浏览器窗口）
 # ============================================================
 
 set -e
@@ -26,12 +26,13 @@ BLUE='\033[0;34m'
 NC='\033[0m'
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 BACKEND_DIR="$PROJECT_ROOT/backend"
 FRONTEND_DIR="$PROJECT_ROOT/frontend"
 E2E_DIR="$PROJECT_ROOT/tests/e2e"
 SCREENSHOT_DIR="$BACKEND_DIR/outputs/e2e_screenshots"
 LOG_DIR="$PROJECT_ROOT/logs"
+UV_RUN=(uv run --project "$BACKEND_DIR")
 
 BACKEND_PORT=5001
 FRONTEND_PORT=5173
@@ -118,7 +119,7 @@ if [ "$TEST_ONLY" = false ]; then
         echo -e "${YELLOW}后端未运行，启动中...${NC}"
         mkdir -p "$LOG_DIR"
         TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
-        cd "$BACKEND_DIR" && python app.py > "$LOG_DIR/backend_e2e_${TIMESTAMP}.log" 2>&1 &
+        cd "$BACKEND_DIR" && "${UV_RUN[@]}" python app.py > "$LOG_DIR/backend_e2e_${TIMESTAMP}.log" 2>&1 &
         BACKEND_PID=$!
         STARTED_BACKEND=true
     else
@@ -186,17 +187,17 @@ cd "$PROJECT_ROOT"
 
 if [ "$SMOKE" = true ]; then
     echo -e "  运行 smoke 测试 (TC-01 + TC-02)..."
-    python -m pytest tests/e2e/test_tc01_home_load.py tests/e2e/test_tc02_blog_gen.py \
+    "${UV_RUN[@]}" pytest tests/e2e/test_tc01_home_load.py tests/e2e/test_tc02_blog_gen.py \
         -v --tb=short $EXTRA_PYTEST_ARGS 2>&1 | tee "$LOG_DIR/e2e_result_$(date +%H%M%S).log"
     TEST_EXIT=$?
 elif [ "$CHAIN" = true ]; then
     echo -e "  运行全链路闭环测试 (TC-16)..."
-    python -m pytest tests/e2e/test_tc16_full_chain.py \
+    "${UV_RUN[@]}" pytest tests/e2e/test_tc16_full_chain.py \
         -v --tb=short $EXTRA_PYTEST_ARGS 2>&1 | tee "$LOG_DIR/e2e_result_$(date +%H%M%S).log"
     TEST_EXIT=$?
 else
     echo -e "  运行完整 E2E 测试..."
-    python -m pytest tests/e2e/ \
+    "${UV_RUN[@]}" pytest tests/e2e/ \
         -v --tb=short $EXTRA_PYTEST_ARGS 2>&1 | tee "$LOG_DIR/e2e_result_$(date +%H%M%S).log"
     TEST_EXIT=$?
 fi
@@ -217,10 +218,10 @@ echo -e "  日志: ${LOG_COUNT} 个 → $SCREENSHOT_DIR"
 
 echo -e "\n${BLUE}[Step 5] 日志分析${NC}"
 ANALYSIS_REPORT="$LOG_DIR/e2e_analysis_$(date +%H%M%S).json"
-python "$SCRIPT_DIR/analyze_e2e_logs.py" --since 10m --output "$ANALYSIS_REPORT" 2>/dev/null
+"${UV_RUN[@]}" python "$SCRIPT_DIR/analyze_logs.py" --since 10m --output "$ANALYSIS_REPORT" 2>/dev/null
 if [ -f "$ANALYSIS_REPORT" ]; then
-    HEALTH=$(python -c "import json; d=json.load(open('$ANALYSIS_REPORT')); print(d.get('health',{}).get('status','UNKNOWN'))" 2>/dev/null || echo "UNKNOWN")
-    ISSUES=$(python -c "import json; d=json.load(open('$ANALYSIS_REPORT')); print(d.get('health',{}).get('total_issues',0))" 2>/dev/null || echo "?")
+    HEALTH=$("${UV_RUN[@]}" python -c "import json; d=json.load(open('$ANALYSIS_REPORT')); print(d.get('health',{}).get('status','UNKNOWN'))" 2>/dev/null || echo "UNKNOWN")
+    ISSUES=$("${UV_RUN[@]}" python -c "import json; d=json.load(open('$ANALYSIS_REPORT')); print(d.get('health',{}).get('total_issues',0))" 2>/dev/null || echo "?")
     if [ "$HEALTH" = "GREEN" ]; then
         echo -e "  ${GREEN}健康度: $HEALTH (问题: $ISSUES)${NC}"
     elif [ "$HEALTH" = "RED" ]; then


### PR DESCRIPTION
## 主要改动

- 将 `scripts/run_e2e.sh` 迁移到 `tests/e2e/tools/run_e2e.sh`
- 将 `scripts/analyze_e2e_logs.py` 迁移并简化命名为 `tests/e2e/tools/analyze_logs.py`
- 修正迁移后的仓库根目录计算和脚本互相引用
- 统一通过 `uv run --project backend` 启动 Python、pytest 和日志分析器
- 在维护中的测试指南补充一键运行和独立日志分析命令
- 更新 CHANGELOG 和实施计划

## 验证

- `bash -n tests/e2e/tools/run_e2e.sh` 通过
- `analyze_logs.py` 编译、项目根解析和实际 JSON 输出通过
- `--test-only` 服务保护分支使用隔离测试替身验证通过
- `uv lock --check --project backend` 解析 114 个包
- 旧 `scripts/` 路径引用检查和 diff 检查通过
- 独立代码审查无阻塞问题

## 说明

未运行会调用真实服务和 LLM 的完整 E2E。脚本原有的 `tee`/`pipefail` 退出码问题未在本次纯路径迁移中修改，建议后续单独处理。