### PR TITLE
refactor: establish centralized runtime path configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ backend/coverage.lcov
 # 缓存数据库（可能含敏感信息）
 backend/cache/
 
+# 统一运行时数据
+/var/
+
 # WhatsApp 网关旧路径（迁移期间保护本地认证数据）
 whatsapp-gateway/store/
 
@@ -42,7 +45,6 @@ eggs/
 /lib64/
 parts/
 sdist/
-var/
 wheels/
 pip-wheel-metadata/
 share/python-wheels/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the Vibe Blog project will be documented in this file.
 
 ---
 
+## 2026-07-25
+
+### Changed
+- 🔧 **运行路径基础计划** — 明确以无副作用配置对象建立 `var/` 运行目录边界，并通过完整回归和浏览器 E2E 验证原有逻辑。
+
 ## 2026-07-22
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the Vibe Blog project will be documented in this file.
 
 ### Changed
 - 🔧 **运行路径基础计划** — 明确以无副作用配置对象建立 `var/` 运行目录边界，并通过完整回归和浏览器 E2E 验证原有逻辑。
+- 🔧 **运行路径配置边界** — 新增统一的 `RuntimePaths` 解析对象与兼容约定，不改变现有日志、输出、上传和缓存调用路径。
 
 ## 2026-07-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to the Vibe Blog project will be documented in this file.
 
 ### Changed
 - 🔧 **运行路径基础计划** — 明确以无副作用配置对象建立 `var/` 运行目录边界，并通过完整回归和浏览器 E2E 验证原有逻辑。
-- 🔧 **运行路径配置边界** — 新增统一的 `RuntimePaths` 解析对象与兼容约定，不改变现有日志、输出、上传和缓存调用路径。
+- 🔧 **运行路径配置边界** — 新增统一的 `RuntimePaths` 解析对象与空配置安全回退，不改变现有日志、输出、上传和缓存调用路径。
 
 ## 2026-07-22
 

--- a/backend/infrastructure/__init__.py
+++ b/backend/infrastructure/__init__.py
@@ -1,0 +1,3 @@
+from .paths import RuntimePaths
+
+__all__ = ["RuntimePaths"]

--- a/backend/infrastructure/paths.py
+++ b/backend/infrastructure/paths.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+@dataclass(frozen=True)
+class RuntimePaths:
+    project_root: Path
+    runtime_root: Path
+    logs: Path
+    outputs: Path
+    uploads: Path
+    cache: Path
+    screenshots: Path
+
+    @classmethod
+    def from_env(
+        cls,
+        environ: Mapping[str, str] | None = None,
+        *,
+        project_root: Path | None = None,
+    ) -> "RuntimePaths":
+        env = os.environ if environ is None else environ
+        root = (project_root or _PROJECT_ROOT).resolve()
+        runtime_root = Path(env.get("VIBE_RUNTIME_DIR", "var")).expanduser()
+        if not runtime_root.is_absolute():
+            runtime_root = root / runtime_root
+        runtime_root = runtime_root.resolve()
+
+        return cls(
+            project_root=root,
+            runtime_root=runtime_root,
+            logs=runtime_root / "logs",
+            outputs=runtime_root / "outputs",
+            uploads=runtime_root / "uploads",
+            cache=runtime_root / "cache",
+            screenshots=runtime_root / "screenshots",
+        )

--- a/backend/infrastructure/paths.py
+++ b/backend/infrastructure/paths.py
@@ -28,7 +28,10 @@ class RuntimePaths:
     ) -> "RuntimePaths":
         env = os.environ if environ is None else environ
         root = (project_root or _PROJECT_ROOT).resolve()
-        runtime_root = Path(env.get("VIBE_RUNTIME_DIR", "var")).expanduser()
+        runtime_value = env.get("VIBE_RUNTIME_DIR", "var")
+        if not runtime_value.strip():
+            runtime_value = "var"
+        runtime_root = Path(runtime_value).expanduser()
         if not runtime_root.is_absolute():
             runtime_root = root / runtime_root
         runtime_root = runtime_root.resolve()

--- a/backend/tests/unit/test_runtime_paths.py
+++ b/backend/tests/unit/test_runtime_paths.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pytest
+
 from infrastructure.paths import RuntimePaths
 
 
@@ -36,3 +38,16 @@ def test_preserves_absolute_runtime_override(tmp_path: Path) -> None:
     )
 
     assert paths.runtime_root == target
+
+
+@pytest.mark.parametrize("value", ["", "   "])
+def test_empty_runtime_override_uses_default(
+    tmp_path: Path,
+    value: str,
+) -> None:
+    paths = RuntimePaths.from_env(
+        {"VIBE_RUNTIME_DIR": value},
+        project_root=tmp_path,
+    )
+
+    assert paths.runtime_root == tmp_path / "var"

--- a/backend/tests/unit/test_runtime_paths.py
+++ b/backend/tests/unit/test_runtime_paths.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+from infrastructure.paths import RuntimePaths
+
+
+def test_defaults_to_repository_var_layout(tmp_path: Path) -> None:
+    paths = RuntimePaths.from_env({}, project_root=tmp_path)
+
+    assert paths.project_root == tmp_path
+    assert paths.runtime_root == tmp_path / "var"
+    assert paths.logs == tmp_path / "var" / "logs"
+    assert paths.outputs == tmp_path / "var" / "outputs"
+    assert paths.uploads == tmp_path / "var" / "uploads"
+    assert paths.cache == tmp_path / "var" / "cache"
+    assert paths.screenshots == tmp_path / "var" / "screenshots"
+    assert not paths.runtime_root.exists()
+
+
+def test_resolves_relative_runtime_override_from_project_root(
+    tmp_path: Path,
+) -> None:
+    paths = RuntimePaths.from_env(
+        {"VIBE_RUNTIME_DIR": "state"},
+        project_root=tmp_path,
+    )
+
+    assert paths.runtime_root == tmp_path / "state"
+
+
+def test_preserves_absolute_runtime_override(tmp_path: Path) -> None:
+    target = tmp_path / "external-state"
+
+    paths = RuntimePaths.from_env(
+        {"VIBE_RUNTIME_DIR": str(target)},
+        project_root=tmp_path / "project",
+    )
+
+    assert paths.runtime_root == target

--- a/docs/architecture/runtime-paths.md
+++ b/docs/architecture/runtime-paths.md
@@ -21,7 +21,8 @@ VIBE_RUNTIME_DIR=/srv/vibe-blog/state
 ```
 
 A relative override is resolved from the repository root. An absolute override
-is preserved.
+is preserved. Empty and whitespace-only values are treated as unset and fall
+back to the repository `var/` directory.
 
 ## Compatibility Contract
 

--- a/docs/architecture/runtime-paths.md
+++ b/docs/architecture/runtime-paths.md
@@ -1,0 +1,34 @@
+# Runtime Paths
+
+VibeBlog runtime state will converge on a single repository-level `var/`
+directory:
+
+```text
+var/
+├── logs/
+├── outputs/
+├── uploads/
+├── cache/
+└── screenshots/
+```
+
+The `infrastructure.paths.RuntimePaths` value object defines this target
+layout. By default, it resolves `var/` relative to the repository root.
+Set `VIBE_RUNTIME_DIR` to use another root:
+
+```bash
+VIBE_RUNTIME_DIR=/srv/vibe-blog/state
+```
+
+A relative override is resolved from the repository root. An absolute override
+is preserved.
+
+## Compatibility Contract
+
+- Resolving paths does not create directories.
+- Existing runtime consumers keep their current paths in the foundation PR.
+- Existing logs, outputs, uploads, caches, and screenshots are not moved or
+  deleted automatically.
+- Each consumer will migrate in a focused follow-up PR with an old-path read
+  fallback where persisted data must remain accessible.
+- The repository-level `var/` directory is ignored by Git.

--- a/docs/plans/2026-07-25-runtime-path-foundation.md
+++ b/docs/plans/2026-07-25-runtime-path-foundation.md
@@ -54,6 +54,18 @@ def test_preserves_absolute_runtime_override(tmp_path: Path) -> None:
         project_root=tmp_path / "project",
     )
     assert paths.runtime_root == target
+
+
+@pytest.mark.parametrize("value", ["", "   "])
+def test_empty_runtime_override_uses_default(
+    tmp_path: Path,
+    value: str,
+) -> None:
+    paths = RuntimePaths.from_env(
+        {"VIBE_RUNTIME_DIR": value},
+        project_root=tmp_path,
+    )
+    assert paths.runtime_root == tmp_path / "var"
 ```
 
 **Step 3: Run tests and verify RED**
@@ -107,7 +119,10 @@ class RuntimePaths:
     ) -> "RuntimePaths":
         env = os.environ if environ is None else environ
         root = (project_root or _PROJECT_ROOT).resolve()
-        runtime_root = Path(env.get("VIBE_RUNTIME_DIR", "var")).expanduser()
+        runtime_value = env.get("VIBE_RUNTIME_DIR", "var")
+        if not runtime_value.strip():
+            runtime_value = "var"
+        runtime_root = Path(runtime_value).expanduser()
         if not runtime_root.is_absolute():
             runtime_root = root / runtime_root
         runtime_root = runtime_root.resolve()
@@ -139,7 +154,7 @@ cd backend
 UV_CACHE_DIR=/private/tmp/vibe-blog-uv-cache-runtime-paths uv run --frozen pytest tests/unit/test_runtime_paths.py -v
 ```
 
-Expected: 3 tests pass.
+Expected: 5 tests pass.
 
 ### Task 3: Document the boundary
 

--- a/docs/plans/2026-07-25-runtime-path-foundation.md
+++ b/docs/plans/2026-07-25-runtime-path-foundation.md
@@ -1,0 +1,250 @@
+# Runtime Path Foundation Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Introduce one side-effect-free source of truth for the target `var/` runtime layout without changing any existing runtime consumer.
+
+**Architecture:** Add an immutable `RuntimePaths` value object under `backend/infrastructure/`. It resolves the repository root, an optional `VIBE_RUNTIME_DIR`, and the five target runtime categories, but it never creates or moves data. Existing configuration and call sites remain untouched until the next PR.
+
+**Tech Stack:** Python 3.10+, pathlib, dataclasses, pytest, uv
+
+---
+
+### Task 1: Specify runtime path resolution
+
+**Files:**
+- Create: `backend/tests/unit/test_runtime_paths.py`
+
+**Step 1: Write failing default-layout tests**
+
+```python
+from pathlib import Path
+
+from infrastructure.paths import RuntimePaths
+
+
+def test_defaults_to_repository_var_layout(tmp_path: Path) -> None:
+    paths = RuntimePaths.from_env({}, project_root=tmp_path)
+
+    assert paths.project_root == tmp_path
+    assert paths.runtime_root == tmp_path / "var"
+    assert paths.logs == tmp_path / "var" / "logs"
+    assert paths.outputs == tmp_path / "var" / "outputs"
+    assert paths.uploads == tmp_path / "var" / "uploads"
+    assert paths.cache == tmp_path / "var" / "cache"
+    assert paths.screenshots == tmp_path / "var" / "screenshots"
+    assert not paths.runtime_root.exists()
+```
+
+**Step 2: Write failing environment-override tests**
+
+```python
+def test_resolves_relative_runtime_override_from_project_root(tmp_path: Path) -> None:
+    paths = RuntimePaths.from_env(
+        {"VIBE_RUNTIME_DIR": "state"},
+        project_root=tmp_path,
+    )
+    assert paths.runtime_root == tmp_path / "state"
+
+
+def test_preserves_absolute_runtime_override(tmp_path: Path) -> None:
+    target = tmp_path / "external-state"
+    paths = RuntimePaths.from_env(
+        {"VIBE_RUNTIME_DIR": str(target)},
+        project_root=tmp_path / "project",
+    )
+    assert paths.runtime_root == target
+```
+
+**Step 3: Run tests and verify RED**
+
+Run:
+
+```bash
+cd backend
+UV_CACHE_DIR=/private/tmp/vibe-blog-uv-cache-runtime-paths uv run --frozen pytest tests/unit/test_runtime_paths.py -v
+```
+
+Expected: collection fails with `ModuleNotFoundError: No module named 'infrastructure.paths'`.
+
+### Task 2: Implement the side-effect-free path object
+
+**Files:**
+- Create: `backend/infrastructure/paths.py`
+- Modify: `backend/infrastructure/__init__.py`
+- Test: `backend/tests/unit/test_runtime_paths.py`
+
+**Step 1: Add the minimal implementation**
+
+```python
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+@dataclass(frozen=True)
+class RuntimePaths:
+    project_root: Path
+    runtime_root: Path
+    logs: Path
+    outputs: Path
+    uploads: Path
+    cache: Path
+    screenshots: Path
+
+    @classmethod
+    def from_env(
+        cls,
+        environ: Mapping[str, str] | None = None,
+        *,
+        project_root: Path | None = None,
+    ) -> "RuntimePaths":
+        env = os.environ if environ is None else environ
+        root = (project_root or _PROJECT_ROOT).resolve()
+        runtime_root = Path(env.get("VIBE_RUNTIME_DIR", "var")).expanduser()
+        if not runtime_root.is_absolute():
+            runtime_root = root / runtime_root
+        runtime_root = runtime_root.resolve()
+        return cls(
+            project_root=root,
+            runtime_root=runtime_root,
+            logs=runtime_root / "logs",
+            outputs=runtime_root / "outputs",
+            uploads=runtime_root / "uploads",
+            cache=runtime_root / "cache",
+            screenshots=runtime_root / "screenshots",
+        )
+```
+
+**Step 2: Export the public boundary**
+
+```python
+from .paths import RuntimePaths
+
+__all__ = ["RuntimePaths"]
+```
+
+**Step 3: Run focused tests and verify GREEN**
+
+Run:
+
+```bash
+cd backend
+UV_CACHE_DIR=/private/tmp/vibe-blog-uv-cache-runtime-paths uv run --frozen pytest tests/unit/test_runtime_paths.py -v
+```
+
+Expected: 3 tests pass.
+
+### Task 3: Document the boundary
+
+**Files:**
+- Create: `docs/architecture/runtime-paths.md`
+- Modify: `.gitignore`
+- Modify: `CHANGELOG.md`
+
+**Step 1: Document the target layout and compatibility contract**
+
+Document `VIBE_RUNTIME_DIR`, all five derived paths, and these constraints:
+
+- no directories are created during import or resolution;
+- existing consumers continue using their current locations in this PR;
+- old data is never moved or deleted automatically;
+- consumer migration occurs in later focused PRs.
+
+**Step 2: Make the root ignore rule explicit**
+
+Replace the generic `var/` rule with `/var/` so only repository runtime state is hidden.
+
+**Step 3: Update the changelog**
+
+Add the plan and runtime-path foundation entries under `2026-07-25`.
+
+**Step 4: Verify ignore behavior**
+
+Run:
+
+```bash
+git check-ignore -v var/logs/example.log
+git check-ignore -q backend/var/example
+```
+
+Expected: the root path is ignored; the nested path is not ignored by the root-specific rule.
+
+### Task 4: Run regression and end-to-end gates
+
+**Files:**
+- No committed file changes.
+
+**Step 1: Run the complete non-LLM backend suite**
+
+```bash
+cd backend
+UV_CACHE_DIR=/private/tmp/vibe-blog-uv-cache-runtime-paths uv run --frozen pytest -v -m "not llm"
+```
+
+Expected: all selected tests pass.
+
+**Step 2: Run frontend tests and production build**
+
+```bash
+cd frontend
+npm ci
+npm test -- --run
+npm run build
+```
+
+Expected: tests and build pass.
+
+**Step 3: Start the actual local stack**
+
+```bash
+bash docker/start-local.sh
+```
+
+Expected: Flask listens on 5001, Vite listens on 5173, and `GET /health` succeeds.
+
+**Step 4: Run browser smoke E2E**
+
+```bash
+RUN_E2E_TESTS=1 backend/.venv/bin/python -m pytest \
+  tests/e2e/test_tc01_home_load.py \
+  tests/e2e/test_tc07_navigation.py \
+  tests/e2e/test_tc08_theme.py -v
+```
+
+Expected: all smoke cases pass without using an LLM API.
+
+**Step 5: Verify the final diff**
+
+```bash
+git diff --check
+git status --short
+rg -n "RuntimePaths|VIBE_RUNTIME_DIR" backend docs
+```
+
+Expected: no whitespace errors, no generated artifacts, and no existing runtime consumer imports the new module.
+
+### Task 5: Review and publish
+
+**Files:**
+- No additional implementation files.
+
+**Step 1: Request independent code review**
+
+Review the complete diff against the repository organization design and the no-behavior-change constraint.
+
+**Step 2: Push and create one focused PR**
+
+Use title:
+
+```text
+refactor: establish centralized runtime path configuration
+```
+
+The PR description must include unit, backend, frontend, startup, health, and Playwright E2E evidence.


### PR DESCRIPTION
## 变更说明

- 新增不可变的 `RuntimePaths` 配置边界，统一定义 `var/logs`、`outputs`、`uploads`、`cache` 和 `screenshots` 目标路径。
- 支持 `VIBE_RUNTIME_DIR` 相对路径与绝对路径覆盖；空值和纯空白值安全回退到 `var/`。
- 当前 PR 不迁移任何调用方、不移动现有数据、不主动创建目录，因此不会改变现有运行逻辑。
- 将仓库级运行目录忽略规则明确为 `/var/`，并补充架构说明、实施计划和 CHANGELOG。

## 验证结果

- `uv sync --extra test --frozen`：通过，冻结环境安装 108 个包。
- 路径配置单元测试：5 passed。
- 后端非 LLM 测试：1155 passed，12 skipped；Python 3.10/3.11/3.12 由本 PR CI 继续验证。
- 前端 Vitest：35 个测试文件、445 个测试全部通过。
- 前端生产构建：通过。
- 冻结环境启动 Flask（5002），`/health` 返回正常。
- Vite（5174）+ Playwright 冒烟验证：首页、编辑器输入、生成按钮、主题切换和博客页导航均通过。
- `git diff --check`：通过。
- 独立代码审查：无遗留问题。

## 兼容性说明

这是 Issue #110 渐进迁移计划的 PR 1，仅建立路径配置基础。现有 logs、outputs、uploads、cache 和截图路径将在后续独立 PR 中逐类迁移，并保留旧路径读取兼容。

## 致谢\n\n感谢 **freedomgod**（`wwhfree@qq.com`）对原始方案和实现工作的贡献。

Tracks #110