### PR TITLE
refactor: establish backend package boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the Vibe Blog project will be documented in this file.
 ## 2026-07-25
 
 ### Changed
+- ♻️ **后端包边界基线** — 建立 repositories、models、shared 与 infrastructure 子包骨架，并用 AST 架构测试约束底层包不得反向依赖 API、services 或 Flask。
 - 🔧 **运行产物统一迁移** — 将日志、生成输出、上传、缓存和 E2E 截图的新写入统一迁入 `var/`，保留旧输出与日志读取兼容及原有 `/outputs/*` URL。
 - 🔧 **运行路径基础计划** — 明确以无副作用配置对象建立 `var/` 运行目录边界，并通过完整回归和浏览器 E2E 验证原有逻辑。
 - 🔧 **运行路径配置边界** — 新增统一的 `RuntimePaths` 解析对象与空配置安全回退，不改变现有日志、输出、上传和缓存调用路径。

--- a/backend/infrastructure/config/__init__.py
+++ b/backend/infrastructure/config/__init__.py
@@ -1,0 +1,1 @@
+"""Runtime and application configuration infrastructure."""

--- a/backend/infrastructure/database/__init__.py
+++ b/backend/infrastructure/database/__init__.py
@@ -1,0 +1,1 @@
+"""Database connections and low-level persistence infrastructure."""

--- a/backend/infrastructure/logging/__init__.py
+++ b/backend/infrastructure/logging/__init__.py
@@ -1,0 +1,1 @@
+"""Application logging infrastructure."""

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -1,0 +1,1 @@
+"""Framework-neutral domain and transport-independent data models."""

--- a/backend/repositories/__init__.py
+++ b/backend/repositories/__init__.py
@@ -1,0 +1,1 @@
+"""Persistence interfaces and implementations, grouped by resource."""

--- a/backend/repositories/database/__init__.py
+++ b/backend/repositories/database/__init__.py
@@ -1,0 +1,1 @@
+"""Blog and application database repositories."""

--- a/backend/repositories/documents/__init__.py
+++ b/backend/repositories/documents/__init__.py
@@ -1,0 +1,1 @@
+"""Document persistence repositories."""

--- a/backend/repositories/tasks/__init__.py
+++ b/backend/repositories/tasks/__init__.py
@@ -1,0 +1,1 @@
+"""Task and scheduling persistence repositories."""

--- a/backend/shared/__init__.py
+++ b/backend/shared/__init__.py
@@ -1,0 +1,1 @@
+"""Business-neutral helpers shared across backend layers."""

--- a/backend/tests/architecture/__init__.py
+++ b/backend/tests/architecture/__init__.py
@@ -1,0 +1,1 @@
+"""Architecture policy tests."""

--- a/backend/tests/architecture/test_package_boundaries.py
+++ b/backend/tests/architecture/test_package_boundaries.py
@@ -1,0 +1,88 @@
+import ast
+import importlib
+from pathlib import Path
+
+import pytest
+
+
+BACKEND_ROOT = Path(__file__).resolve().parents[2]
+
+BOUNDARY_PACKAGES = (
+    "repositories",
+    "repositories.database",
+    "repositories.documents",
+    "repositories.tasks",
+    "models",
+    "shared",
+    "infrastructure.config",
+    "infrastructure.database",
+    "infrastructure.logging",
+)
+
+FORBIDDEN_IMPORTS = {
+    "services": {"api", "routes", "flask"},
+    "repositories": {"api", "routes", "services", "flask"},
+    "models": {"api", "routes", "services", "repositories", "infrastructure", "flask"},
+    "shared": {"api", "routes", "services", "repositories", "infrastructure", "flask"},
+    "infrastructure": {"api", "routes", "services", "repositories", "flask"},
+}
+
+LEGACY_ALLOWED_IMPORTS = {
+    Path("services/blog_generator/queue_bridge.py"): {"flask"},
+    Path("services/blog_generator/blog_service.py"): {"flask"},
+}
+
+
+@pytest.mark.parametrize("package", BOUNDARY_PACKAGES)
+def test_boundary_package_is_importable(package):
+    assert importlib.import_module(package)
+
+
+def _top_level_imports(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    imports = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.update(alias.name.split(".", 1)[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imports.add(node.module.split(".", 1)[0])
+    return imports
+
+
+def _find_forbidden_imports(path: Path, forbidden: set[str]) -> set[str]:
+    return {
+        imported
+        for imported in _top_level_imports(path)
+        if any(
+            imported == prefix or imported.startswith(f"{prefix}_")
+            for prefix in forbidden
+        )
+    }
+
+
+def test_flask_extensions_are_treated_as_framework_imports(tmp_path):
+    source = tmp_path / "example.py"
+    source.write_text("from flask_cors import CORS\n", encoding="utf-8")
+
+    assert _find_forbidden_imports(source, {"flask"}) == {"flask_cors"}
+
+
+def test_relative_imports_cannot_escape_a_boundary(tmp_path):
+    source = tmp_path / "example.py"
+    source.write_text("from ..services import generator\n", encoding="utf-8")
+
+    assert _find_forbidden_imports(source, {"services"}) == {"services"}
+
+
+@pytest.mark.parametrize("package,forbidden", FORBIDDEN_IMPORTS.items())
+def test_lower_layers_do_not_import_upper_layers(package, forbidden):
+    violations = []
+    for path in (BACKEND_ROOT / package).rglob("*.py"):
+        relative_path = path.relative_to(BACKEND_ROOT)
+        illegal = _find_forbidden_imports(path, forbidden) - LEGACY_ALLOWED_IMPORTS.get(
+            relative_path, set()
+        )
+        if illegal:
+            violations.append(f"{relative_path}: {sorted(illegal)}")
+
+    assert not violations, "Invalid dependency direction:\n" + "\n".join(violations)

--- a/docs/architecture/backend-boundaries.md
+++ b/docs/architecture/backend-boundaries.md
@@ -1,0 +1,39 @@
+# Backend Package Boundaries
+
+VibeBlog evolves toward the following dependency direction:
+
+```text
+api -> services -> repositories -> infrastructure
+                 -> models
+                 -> shared
+```
+
+The packages introduced in this baseline are intentionally empty. Capability
+implementations move in later focused pull requests; this PR only reserves the
+ownership boundaries and makes them enforceable.
+
+## Responsibilities
+
+| Package | Owns | Must not own |
+| --- | --- | --- |
+| `api` | HTTP parsing, validation, response conversion | Business workflows or persistence |
+| `services` | Use cases and business orchestration | Flask routes or database connection setup |
+| `repositories` | Persistence interfaces and resource-specific storage | HTTP handling or business rules |
+| `models` | Stable framework-neutral data structures | Flask, services, repositories, or infrastructure |
+| `infrastructure` | Configuration, connections, logging, prompts | API or business orchestration |
+| `shared` | Small business-neutral cross-cutting helpers | Feature-specific workflows or infrastructure |
+
+## Enforcement
+
+`backend/tests/architecture/test_package_boundaries.py` parses Python imports
+with the standard `ast` module. It prevents lower layers from importing upper
+layers while later migration PRs populate the packages. Relative imports inside
+the same boundary remain allowed.
+
+Two existing blog-generation modules that access Flask `current_app` are
+recorded in an explicit legacy allowlist. The test rejects any new Flask access;
+the existing entries are removed when the blog-generation boundary migrates.
+
+Legacy modules are not moved by this baseline. Each later PR must move one
+capability, retain a thin old-import forwarding module, and extend the boundary
+tests when that capability becomes governed by the new package.


### PR DESCRIPTION
## 变更说明

- 建立 `repositories/{database,documents,tasks}`、`models`、`shared` 和 `infrastructure/{config,database,logging}` 正式 Python 包边界。
- 新增 AST 架构测试，禁止 services、repositories、models、shared 和 infrastructure 发生反向依赖。
- 检测绝对导入、相对导入逃逸以及 `flask_*` 扩展依赖。
- 将两个现存的 blog-generation Flask 依赖记录为显式 legacy allowlist；禁止新增，计划在博客主链路迁移时删除。
- 补充职责、依赖方向、兼容迁移规则和 CHANGELOG。

## 验证结果

- 架构测试：16 passed。
- 完整后端非 LLM 回归：1183 passed，12 skipped，覆盖率 41.92%。
- 前端 Vitest：35 个测试文件、445 个测试全部通过。
- 前端生产构建：通过，未提交生成的 `dist`。
- Flask 5002 启动与 `/health`：通过。
- Vite 5174 + Playwright：首页、编辑器输入、生成按钮、主题切换和博客页导航通过。
- `git diff --check`：通过。

## 兼容性说明

本 PR 只建立空包和可执行依赖规则，不移动现有实现、不修改 API、导入路径或运行逻辑。

## 堆叠关系

本 PR 是 Issue #110 迁移计划的 PR 3，依赖 PR #125。当前 base 暂设为 `codex/runtime-artifact-migration`；前序 PR 合并后会依次调整 base。

Tracks #110

## 致谢

感谢 **freedomgod**（`wwhfree@qq.com`）对原始方案和实现工作的贡献。