### PR TITLE
refactor: establish blog generation and review boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the Vibe Blog project will be documented in this file.
 ## 2026-07-25
 
 ### Changed
+- ♻️ **博客生成与审核公共边界** — 新增 `services/blog_generation` 与 `services/review` 稳定门面，迁移外部调用方并保持核心 LangGraph 实现、Agent 身份和单例状态不变。
 - ♻️ **HTTP API 能力边界** — 将 Flask 应用工厂与 13 个 Blueprint 路由归入 `api/`，建立 schemas/errors 边界，修正静态资源路径并保留旧 `routes.*` patch 与导入兼容。
 - ♻️ **文档与发布能力边界** — 将解析、知识与 Book 能力归入 `services/documents/`，OSS、XHS 与发布工作流归入 `services/publishing/`，修正资源路径并保留旧导入兼容。
 - ♻️ **媒体服务能力边界** — 将图片、图片风格、视频、视频序列和 Sora 实现归入 `services/media/`，修正资源与 OSS 依赖路径，并以模块别名保留旧入口兼容。

--- a/backend/api/routes/blog_routes.py
+++ b/backend/api/routes/blog_routes.py
@@ -65,7 +65,7 @@ def init_blog_services(app_config):
 
         # 75.02 Serper Google 搜索
         try:
-            from services.blog_generator.services.serper_search_service import init_serper_service
+            from services.blog_generation import init_serper_service
             serper = init_serper_service(app_config)
             if serper and serper.is_available():
                 logger.info("Serper Google 搜索服务已初始化")
@@ -74,7 +74,7 @@ def init_blog_services(app_config):
 
         # 75.07 搜狗搜索（腾讯云 SearchPro）
         try:
-            from services.blog_generator.services.sogou_search_service import init_sogou_service
+            from services.blog_generation import init_sogou_service
             sogou = init_sogou_service(app_config)
             if sogou:
                 logger.info("搜狗搜索服务已初始化")

--- a/backend/scripts/test_mini_blog_v2.py
+++ b/backend/scripts/test_mini_blog_v2.py
@@ -35,10 +35,10 @@ def test_mini_blog(topic: str):
     load_dotenv()
     
     import os
-    from backend.services.blog_generator.blog_service import init_blog_service, get_blog_service
+    from backend.services.blog_generation import init_blog_service, get_blog_service
     from backend.services.llm import init_llm_service
     from backend.services.media import init_image_service
-    from backend.services.blog_generator.services.search_service import init_search_service
+    from backend.services.blog_generation import init_search_service
     
     # 构建配置
     config = {

--- a/backend/scripts/test_toc_planner.py
+++ b/backend/scripts/test_toc_planner.py
@@ -17,8 +17,8 @@ load_dotenv()
 
 def test_full_pipeline():
     from services.llm import init_llm_service
-    from services.blog_generator.blog_service import init_blog_service, get_blog_service
-    from services.blog_generator.services.search_service import init_search_service
+    from services.blog_generation import init_blog_service, get_blog_service
+    from services.blog_generation import init_search_service
     from services.media import init_image_service
 
     config = {

--- a/backend/services/__init__.py
+++ b/backend/services/__init__.py
@@ -23,13 +23,13 @@ _EXPORTS = {
     "get_task_manager": ("services.task_service", "get_task_manager"),
     "PipelineService": ("services.pipeline_service", "PipelineService"),
     "create_pipeline_service": ("services.pipeline_service", "create_pipeline_service"),
-    "BlogGenerator": ("services.blog_generator", "BlogGenerator"),
-    "SearchService": ("services.blog_generator", "SearchService"),
-    "init_search_service": ("services.blog_generator", "init_search_service"),
-    "get_search_service": ("services.blog_generator", "get_search_service"),
-    "BlogService": ("services.blog_generator.blog_service", "BlogService"),
-    "init_blog_service": ("services.blog_generator.blog_service", "init_blog_service"),
-    "get_blog_service": ("services.blog_generator.blog_service", "get_blog_service"),
+    "BlogGenerator": ("services.blog_generation", "BlogGenerator"),
+    "SearchService": ("services.blog_generation", "SearchService"),
+    "init_search_service": ("services.blog_generation", "init_search_service"),
+    "get_search_service": ("services.blog_generation", "get_search_service"),
+    "BlogService": ("services.blog_generation", "BlogService"),
+    "init_blog_service": ("services.blog_generation", "init_blog_service"),
+    "get_blog_service": ("services.blog_generation", "get_blog_service"),
 }
 
 __all__ = list(_EXPORTS)

--- a/backend/services/blog_generation/__init__.py
+++ b/backend/services/blog_generation/__init__.py
@@ -1,0 +1,57 @@
+"""Stable public boundary for the long-form blog generation capability."""
+
+from importlib import import_module
+
+
+_EXPORTS = {
+    "BlogGenerator": ("services.blog_generator.generator", "BlogGenerator"),
+    "BlogService": ("services.blog_generator.blog_service", "BlogService"),
+    "SearchService": (
+        "services.blog_generator.services.search_service",
+        "SearchService",
+    ),
+    "extract_article_summary": (
+        "services.blog_generator.blog_service",
+        "extract_article_summary",
+    ),
+    "get_blog_service": (
+        "services.blog_generator.blog_service",
+        "get_blog_service",
+    ),
+    "get_prompt_manager": (
+        "services.blog_generator.prompts",
+        "get_prompt_manager",
+    ),
+    "get_search_service": (
+        "services.blog_generator.services.search_service",
+        "get_search_service",
+    ),
+    "init_blog_service": (
+        "services.blog_generator.blog_service",
+        "init_blog_service",
+    ),
+    "init_search_service": (
+        "services.blog_generator.services.search_service",
+        "init_search_service",
+    ),
+    "init_serper_service": (
+        "services.blog_generator.services.serper_search_service",
+        "init_serper_service",
+    ),
+    "init_sogou_service": (
+        "services.blog_generator.services.sogou_search_service",
+        "init_sogou_service",
+    ),
+}
+
+__all__ = list(_EXPORTS)
+
+
+def __getattr__(name):
+    if name not in _EXPORTS:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    module_name, attribute_name = _EXPORTS[name]
+    value = getattr(import_module(module_name), attribute_name)
+    globals()[name] = value
+    return value

--- a/backend/services/chat/agent_dispatcher.py
+++ b/backend/services/chat/agent_dispatcher.py
@@ -8,11 +8,12 @@ from typing import Optional, Dict, Any, List
 
 from services.blog_generator.agents import (
     ResearcherAgent, PlannerAgent, WriterAgent, CoderAgent,
-    ArtistAgent, ReviewerAgent, AssemblerAgent, SearchCoordinator,
+    ArtistAgent, AssemblerAgent, SearchCoordinator,
 )
 from services.blog_generator.agents.factcheck import FactCheckAgent
 from services.blog_generator.agents.humanizer import HumanizerAgent
 from services.chat.writing_session import WritingSession
+from services.review import ReviewerAgent
 
 logger = logging.getLogger(__name__)
 

--- a/backend/services/documents/book_scanner_service.py
+++ b/backend/services/documents/book_scanner_service.py
@@ -10,7 +10,7 @@ from typing import Dict, Any, List, Optional
 
 from infrastructure.paths import RuntimePaths
 from services.database_service import DatabaseService
-from services.blog_generator.prompts import get_prompt_manager
+from services.blog_generation import get_prompt_manager
 
 logger = logging.getLogger(__name__)
 
@@ -352,7 +352,7 @@ class BookScannerService:
         if not self.llm:
             return 0
 
-        from services.blog_generator.blog_service import extract_article_summary
+        from services.blog_generation import extract_article_summary
 
         count = 0
         for blog in blogs:

--- a/backend/services/homepage_generator_service.py
+++ b/backend/services/homepage_generator_service.py
@@ -7,7 +7,7 @@ from typing import Dict, Any, Optional
 
 from services.database_service import DatabaseService
 from services.outline_expander_service import OutlineExpanderService
-from services.blog_generator.prompts import get_prompt_manager
+from services.blog_generation import get_prompt_manager
 
 logger = logging.getLogger(__name__)
 

--- a/backend/services/media/sora2_service.py
+++ b/backend/services/media/sora2_service.py
@@ -229,7 +229,7 @@ class Sora2Service:
         """
         # 如果没有提供 prompt，使用默认的动画提示词
         if not prompt:
-            from services.blog_generator.prompts import get_prompt_manager
+            from services.blog_generation import get_prompt_manager
             prompt = get_prompt_manager().render_cover_video_prompt()
 
         if remix_target_id:

--- a/backend/services/media/video_service.py
+++ b/backend/services/media/video_service.py
@@ -51,7 +51,7 @@ class Veo3Service:
     @staticmethod
     def get_default_animation_prompt() -> str:
         """获取默认动画提示词（从 Jinja2 模板加载）"""
-        from services.blog_generator.prompts import get_prompt_manager
+        from services.blog_generation import get_prompt_manager
         return get_prompt_manager().render_cover_video_prompt()
 
     def __init__(

--- a/backend/services/outline_expander_service.py
+++ b/backend/services/outline_expander_service.py
@@ -6,7 +6,7 @@ import logging
 from typing import Dict, Any, List, Optional
 
 from services.database_service import DatabaseService
-from services.blog_generator.prompts import get_prompt_manager
+from services.blog_generation import get_prompt_manager
 
 logger = logging.getLogger(__name__)
 

--- a/backend/services/publishing/xhs_service.py
+++ b/backend/services/publishing/xhs_service.py
@@ -68,7 +68,7 @@ class XHSService:
         self.oss_service = oss_service
 
         # 导入 PromptManager
-        from services.blog_generator.prompts import get_prompt_manager
+        from services.blog_generation import get_prompt_manager
         self.prompt_manager = get_prompt_manager()
 
         # 导入智能搜索服务

--- a/backend/services/review/__init__.py
+++ b/backend/services/review/__init__.py
@@ -1,0 +1,27 @@
+"""Stable public boundary for blog quality review capabilities."""
+
+from importlib import import_module
+
+
+_EXPORTS = {
+    "ReviewerAgent": (
+        "services.blog_generator.agents.reviewer",
+        "ReviewerAgent",
+    ),
+    "get_guidelines": (
+        "services.blog_generator.review_guidelines",
+        "get_guidelines",
+    ),
+}
+
+__all__ = list(_EXPORTS)
+
+
+def __getattr__(name):
+    if name not in _EXPORTS:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    module_name, attribute_name = _EXPORTS[name]
+    value = getattr(import_module(module_name), attribute_name)
+    globals()[name] = value
+    return value

--- a/backend/tests/unit/test_blog_review_boundary.py
+++ b/backend/tests/unit/test_blog_review_boundary.py
@@ -1,0 +1,30 @@
+import importlib
+
+
+def test_blog_generation_facade_preserves_core_object_identity():
+    facade = importlib.import_module("services.blog_generation")
+    generator = importlib.import_module("services.blog_generator.generator")
+    blog_service = importlib.import_module("services.blog_generator.blog_service")
+    prompts = importlib.import_module("services.blog_generator.prompts")
+
+    assert facade.BlogGenerator is generator.BlogGenerator
+    assert facade.BlogService is blog_service.BlogService
+    assert facade.get_blog_service is blog_service.get_blog_service
+    assert facade.get_prompt_manager is prompts.get_prompt_manager
+
+
+def test_review_facade_preserves_reviewer_and_guideline_identity():
+    facade = importlib.import_module("services.review")
+    reviewer = importlib.import_module("services.blog_generator.agents.reviewer")
+    guidelines = importlib.import_module("services.blog_generator.review_guidelines")
+
+    assert facade.ReviewerAgent is reviewer.ReviewerAgent
+    assert facade.get_guidelines is guidelines.get_guidelines
+
+
+def test_services_package_uses_blog_generation_facade():
+    services = importlib.import_module("services")
+    facade = importlib.import_module("services.blog_generation")
+
+    assert services.BlogGenerator is facade.BlogGenerator
+    assert services.BlogService is facade.BlogService

--- a/docs/architecture/blog-review-boundary.md
+++ b/docs/architecture/blog-review-boundary.md
@@ -1,0 +1,28 @@
+# Blog Generation and Review Boundaries
+
+External callers use two stable capability facades:
+
+```text
+backend/services/
+├── blog_generation/    # generation, search, prompt, and summary API
+└── review/             # reviewer agent and guideline API
+```
+
+Typical imports are:
+
+```python
+from services.blog_generation import get_blog_service, get_prompt_manager
+from services.review import ReviewerAgent, get_guidelines
+```
+
+## Incremental Core Migration
+
+The LangGraph implementation remains under `services/blog_generator` during
+this phase. It contains many relative imports, module-level state, and existing
+patch targets. Loading those files under a second package name would create
+duplicate module objects and could split graph state or singleton services.
+
+The new facades lazily return the original objects, so external dependencies can
+stabilize first without changing workflow behavior. Moving the internal graph
+package requires a separate migration with an import alias loader or a coordinated
+breaking release; it is intentionally excluded from this low-regression PR.


### PR DESCRIPTION
## 改动范围

- 新增 `services.blog_generation` 稳定公共门面，统一生成、搜索、prompt、摘要和生命周期入口
- 新增 `services.review` 稳定公共门面，暴露 ReviewerAgent 与 guidelines
- 将服务根导出及外部 prompt、摘要、搜索初始化、脚本和聊天审核调用迁到新门面
- 所有门面均懒加载并返回原实现对象，不复制单例或 LangGraph 状态

## 风险控制

本 PR 不直接改名或搬迁 `services/blog_generator` 内部实现。该核心包包含大量相对导入、模块状态与既有 patch 目标；双路径加载会造成模块身份和图状态分裂。内部目录迁移应作为单独的 breaking migration 处理，不纳入本次低回归结构优化。

## 验证

- 门面身份/Agent/生命周期/架构聚焦测试：56 passed
- 后端完整非 LLM 测试：1205 passed, 12 skipped（Python 3.12）
- 前端单元测试：445/445 passed
- 前端生产构建：passed
- Flask 启动与 `/health`：passed
- Playwright：编辑器输入、生成按钮、主题切换、博客导航及页面错误检查均通过
- `git diff --check`：passed

这是结构优化系列的第 9 个堆叠 PR，基于 #131；合并时请按顺序处理。

Tracks #110

## 致谢

感谢 **freedomgod**（`wwhfree@qq.com`）对原始方案和实现工作的贡献。