### PR TITLE
test: remove backend test path patching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the Vibe Blog project will be documented in this file.
 ## 2026-07-25
 
 ### Changed
+- ♻️ **测试导入与兼容清理** — 通过 pytest `pythonpath` 配置取代后端测试中的 53 处 `sys.path` 修补，增加 AST 防回归规则，并记录仍有调用的兼容入口暂缓删除。
 - ♻️ **博客生成与审核公共边界** — 新增 `services/blog_generation` 与 `services/review` 稳定门面，迁移外部调用方并保持核心 LangGraph 实现、Agent 身份和单例状态不变。
 - ♻️ **HTTP API 能力边界** — 将 Flask 应用工厂与 13 个 Blueprint 路由归入 `api/`，建立 schemas/errors 边界，修正静态资源路径并保留旧 `routes.*` patch 与导入兼容。
 - ♻️ **文档与发布能力边界** — 将解析、知识与 Book 能力归入 `services/documents/`，OSS、XHS 与发布工作流归入 `services/publishing/`，修正资源路径并保留旧导入兼容。

--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -1,16 +1,9 @@
 """
 Shared pytest fixtures for VibeBlog backend tests.
 """
-import os
-import sys
 import pytest
 from unittest.mock import Mock, MagicMock
 from typing import Generator
-
-# Add backend directory to Python path
-backend_dir = os.path.dirname(os.path.abspath(__file__))
-sys.path.insert(0, backend_dir)
-
 
 # ============ Flask App Fixtures ============
 

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,4 +1,6 @@
 [pytest]
+pythonpath = .
+
 # Test discovery patterns
 testpaths = tests
 python_files = test_*.py

--- a/backend/tests/api/test_101_113_interrupt_api.py
+++ b/backend/tests/api/test_101_113_interrupt_api.py
@@ -16,13 +16,6 @@ from unittest.mock import patch, MagicMock
 @pytest.fixture
 def app():
     """创建 Flask 测试应用"""
-    import sys
-    import os
-    # 确保 backend 在 sys.path 中
-    backend_dir = os.path.join(os.path.dirname(__file__), '..', '..')
-    if backend_dir not in sys.path:
-        sys.path.insert(0, os.path.abspath(backend_dir))
-
     from flask import Flask
     from routes.blog_routes import blog_bp
 

--- a/backend/tests/architecture/test_package_boundaries.py
+++ b/backend/tests/architecture/test_package_boundaries.py
@@ -86,3 +86,28 @@ def test_lower_layers_do_not_import_upper_layers(package, forbidden):
             violations.append(f"{relative_path}: {sorted(illegal)}")
 
     assert not violations, "Invalid dependency direction:\n" + "\n".join(violations)
+
+
+def _is_sys_path_mutation(node: ast.Call) -> bool:
+    function = node.func
+    return (
+        isinstance(function, ast.Attribute)
+        and function.attr in {"insert", "append"}
+        and isinstance(function.value, ast.Attribute)
+        and function.value.attr == "path"
+        and isinstance(function.value.value, ast.Name)
+        and function.value.value.id == "sys"
+    )
+
+
+def test_tests_do_not_mutate_python_import_path():
+    violations = []
+    paths = [BACKEND_ROOT / "conftest.py", *(BACKEND_ROOT / "tests").rglob("*.py")]
+
+    for path in paths:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call) and _is_sys_path_mutation(node):
+                violations.append(f"{path.relative_to(BACKEND_ROOT)}:{node.lineno}")
+
+    assert not violations, "Tests must use pytest pythonpath configuration:\n" + "\n".join(violations)

--- a/backend/tests/debug_humanizer.py
+++ b/backend/tests/debug_humanizer.py
@@ -3,7 +3,6 @@
 验证 qwen3.5-plus 对 response_format={"type": "json_object"} 的支持情况
 """
 import sys, os, json, time
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 from dotenv import load_dotenv
 load_dotenv(os.path.join(os.path.dirname(__file__), '..', '.env'))

--- a/backend/tests/test_50_search_sources_eval.py
+++ b/backend/tests/test_50_search_sources_eval.py
@@ -158,7 +158,6 @@ CHECK_NAMES = {
 
 
 def get_llm_client():
-    sys.path.insert(0, str(Path(__file__).parent.parent))
     from services.llm_service import get_llm_service, init_llm_service
     llm = get_llm_service()
     if llm is None:
@@ -299,7 +298,6 @@ def main():
 
 
 if __name__ == "__main__":
-    sys.path.insert(0, str(Path(__file__).parent.parent))
     from dotenv import load_dotenv
     load_dotenv(Path(__file__).parent.parent / ".env")
     main()

--- a/backend/tests/test_52_ab_quality_eval.py
+++ b/backend/tests/test_52_ab_quality_eval.py
@@ -224,7 +224,6 @@ def call_judge(topic_config: dict, article: str) -> dict:
         response_text = result.get("response", result.get("content", ""))
     else:
         logger.warning(f"  ⚠️ /api/chat 不可用 ({resp.status_code})，尝试直接调用 LLM...")
-        sys.path.insert(0, str(Path(__file__).parent.parent))
         from services.llm_service import get_llm_service
         llm = get_llm_service()
         response_text = llm.chat(
@@ -356,5 +355,4 @@ def main():
 
 
 if __name__ == "__main__":
-    sys.path.insert(0, str(Path(__file__).parent.parent))
     main()

--- a/backend/tests/test_54_55_ab_quality_eval.py
+++ b/backend/tests/test_54_55_ab_quality_eval.py
@@ -221,7 +221,6 @@ def call_judge(topic: str, article_a: str, article_b: str) -> dict:
     else:
         # 降级：直接用 requests 调本地 LLM
         logger.warning(f"  ⚠️ /api/chat 不可用 ({resp.status_code})，尝试直接调用 LLM...")
-        sys.path.insert(0, str(Path(__file__).parent.parent))
         from services.llm_service import get_llm_service
         llm = get_llm_service()
         response_text = llm.chat(
@@ -412,5 +411,4 @@ def main():
 
 
 if __name__ == "__main__":
-    sys.path.insert(0, str(Path(__file__).parent.parent))
     main()

--- a/backend/tests/test_57_skeleton_design.py
+++ b/backend/tests/test_57_skeleton_design.py
@@ -634,7 +634,6 @@ def call_judge(topic_config: dict, article: str) -> dict:
         response_text = result.get("response", result.get("content", ""))
     else:
         logger.warning(f"  ⚠️ /api/chat 不可用 ({resp.status_code})，尝试直接调用 LLM...")
-        sys.path.insert(0, str(Path(__file__).parent.parent))
         from services.llm_service import get_llm_service
         llm = get_llm_service()
         response_text = llm.chat(
@@ -780,5 +779,4 @@ def main():
 
 
 if __name__ == "__main__":
-    sys.path.insert(0, str(Path(__file__).parent.parent))
     main()

--- a/backend/tests/test_63_humanizer_eval.py
+++ b/backend/tests/test_63_humanizer_eval.py
@@ -171,7 +171,6 @@ CHECK_KEYS = list(CHECK_NAMES.keys())
 
 def get_llm_client():
     """获取 LLM 客户端"""
-    sys.path.insert(0, str(Path(__file__).parent.parent))
     from services.llm_service import get_llm_service, init_llm_service
 
     llm = get_llm_service()
@@ -373,7 +372,6 @@ def main():
 
 
 if __name__ == "__main__":
-    sys.path.insert(0, str(Path(__file__).parent.parent))
     from dotenv import load_dotenv
     load_dotenv(Path(__file__).parent.parent / ".env")
     main()

--- a/backend/tests/test_65_factcheck_eval.py
+++ b/backend/tests/test_65_factcheck_eval.py
@@ -203,7 +203,6 @@ CHECK_NAMES = {
 
 def get_llm_client():
     """获取 LLM 客户端"""
-    sys.path.insert(0, str(Path(__file__).parent.parent))
     from services.llm_service import get_llm_service, init_llm_service
 
     llm = get_llm_service()
@@ -354,7 +353,6 @@ def main():
 
 
 if __name__ == "__main__":
-    sys.path.insert(0, str(Path(__file__).parent.parent))
     from dotenv import load_dotenv
     load_dotenv(Path(__file__).parent.parent / ".env")
     main()

--- a/backend/tests/test_66_reviewer_eval.py
+++ b/backend/tests/test_66_reviewer_eval.py
@@ -188,7 +188,6 @@ PASS_THRESHOLD = 5  # 8 项中至少 5 项通过
 
 
 def get_llm_client():
-    sys.path.insert(0, str(Path(__file__).parent.parent))
     from services.llm_service import get_llm_service, init_llm_service
     llm = get_llm_service()
     if llm is None:
@@ -429,7 +428,6 @@ def main():
 
 
 if __name__ == "__main__":
-    sys.path.insert(0, str(Path(__file__).parent.parent))
     from dotenv import load_dotenv
     load_dotenv(Path(__file__).parent.parent / ".env")
     main()

--- a/backend/tests/test_67_summary_eval.py
+++ b/backend/tests/test_67_summary_eval.py
@@ -220,7 +220,6 @@ CHECK_NAMES = {
 # ============================================================
 
 def get_llm_client():
-    sys.path.insert(0, str(Path(__file__).parent.parent))
     from services.llm_service import get_llm_service, init_llm_service
 
     llm = get_llm_service()
@@ -353,7 +352,6 @@ def main():
 
 
 if __name__ == "__main__":
-    sys.path.insert(0, str(Path(__file__).parent.parent))
     from dotenv import load_dotenv
     load_dotenv(Path(__file__).parent.parent / ".env")
     main()

--- a/backend/tests/test_67_text_cleanup.py
+++ b/backend/tests/test_67_text_cleanup.py
@@ -13,7 +13,6 @@
 import sys
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from utils.text_cleanup import apply_full_cleanup
 

--- a/backend/tests/test_68_01_architecture.py
+++ b/backend/tests/test_68_01_architecture.py
@@ -6,7 +6,6 @@ import pytest
 import sys
 import os
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 from services.blog_generator.style_profile import StyleProfile
 from services.blog_generator.workflow_registry import WorkflowRegistry

--- a/backend/tests/test_68_01_governance.py
+++ b/backend/tests/test_68_01_governance.py
@@ -17,7 +17,6 @@
 import sys
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from services.blog_generator.style_profile import StyleProfile
 from services.blog_generator.workflow_registry import WorkflowRegistry

--- a/backend/tests/test_68_03_workflow_engine.py
+++ b/backend/tests/test_68_03_workflow_engine.py
@@ -6,7 +6,6 @@ import pytest
 import sys
 import os
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 from services.blog_generator.workflow_engine import WorkflowEngine, ResolvedWorkflow, AgentMeta
 from services.blog_generator.style_profile import StyleProfile

--- a/backend/tests/test_69_01_mermaid_fix.py
+++ b/backend/tests/test_69_01_mermaid_fix.py
@@ -19,7 +19,6 @@ from pathlib import Path
 logging.basicConfig(level=logging.INFO, format='%(asctime)s [%(levelname)s] %(message)s')
 logger = logging.getLogger(__name__)
 
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 
 def test_sanitize_mermaid():

--- a/backend/tests/test_69_02_code2prompt.py
+++ b/backend/tests/test_69_02_code2prompt.py
@@ -22,7 +22,6 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 import types
 
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from services.blog_generator.image_enhancement import (
     ImageEnhancementPipeline,

--- a/backend/tests/test_69_04_generator_critic.py
+++ b/backend/tests/test_69_04_generator_critic.py
@@ -22,7 +22,6 @@ import sys
 from pathlib import Path
 from unittest.mock import MagicMock
 
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 
 # ========== GC1-GC2: 模板渲染 ==========

--- a/backend/tests/test_69_05_session_tracker.py
+++ b/backend/tests/test_69_05_session_tracker.py
@@ -30,7 +30,6 @@ import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 
 # ========== ST1-ST2: 初始化 ==========

--- a/backend/tests/test_69_06_style_anchor.py
+++ b/backend/tests/test_69_06_style_anchor.py
@@ -22,7 +22,6 @@ import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 
 class TestStyleAnchorInit:

--- a/backend/tests/test_69_06_style_consistency.py
+++ b/backend/tests/test_69_06_style_consistency.py
@@ -20,7 +20,6 @@ import sys
 from pathlib import Path
 from unittest.mock import MagicMock
 
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 
 # ========== SA1: ArtistAgent 属性 ==========

--- a/backend/tests/test_69_artist_improvements.py
+++ b/backend/tests/test_69_artist_improvements.py
@@ -18,7 +18,6 @@
 import sys
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from services.blog_generator.agents.artist import (
     ArtistAgent,

--- a/backend/tests/test_69_image_critic.py
+++ b/backend/tests/test_69_image_critic.py
@@ -24,7 +24,6 @@ import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 
 class TestImageEvaluatorTemplate:

--- a/backend/tests/test_70_1_1_planner_narrative.py
+++ b/backend/tests/test_70_1_1_planner_narrative.py
@@ -21,7 +21,6 @@ import os
 import json
 
 # 添加 backend 到 path
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 from dotenv import load_dotenv
 load_dotenv(os.path.join(os.path.dirname(__file__), '..', '.env'))

--- a/backend/tests/test_70_1_2_word_allocation_e2e.py
+++ b/backend/tests/test_70_1_2_word_allocation_e2e.py
@@ -28,16 +28,13 @@
 """
 
 import sys
-import os
 import json
 import time
 import argparse
 import logging
 import requests
 
-# 添加当前目录到 Python 路径，以便导入 e2e_utils
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from e2e_utils import (
+from tests.e2e_utils import (
     SSE_HOOK_JS, run_playwright_generation, cancel_task,
     BACKEND_URL, FRONTEND_URL
 )

--- a/backend/tests/test_70_1_7_writer_quality_e2e.py
+++ b/backend/tests/test_70_1_7_writer_quality_e2e.py
@@ -33,7 +33,6 @@ import argparse
 import logging
 import requests
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s [%(levelname)s] %(message)s')
 logger = logging.getLogger(__name__)

--- a/backend/tests/test_70_1_8_writer_fields_e2e.py
+++ b/backend/tests/test_70_1_8_writer_fields_e2e.py
@@ -33,7 +33,6 @@ import argparse
 import logging
 import requests
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s [%(levelname)s] %(message)s')
 logger = logging.getLogger(__name__)

--- a/backend/tests/test_70_consistency_check_eval.py
+++ b/backend/tests/test_70_consistency_check_eval.py
@@ -191,7 +191,6 @@ Agent 输出的 issues 中是否有明显的误报？
 
 def get_llm_client():
     """获取 LLM 客户端"""
-    sys.path.insert(0, str(Path(__file__).parent.parent))
     from services.llm_service import get_llm_service, init_llm_service
 
     llm = get_llm_service()
@@ -368,7 +367,6 @@ def main():
 
 
 if __name__ == "__main__":
-    sys.path.insert(0, str(Path(__file__).parent.parent))
     from dotenv import load_dotenv
     load_dotenv(Path(__file__).parent.parent / ".env")
     main()

--- a/backend/tests/test_71_searcher_boost.py
+++ b/backend/tests/test_71_searcher_boost.py
@@ -19,7 +19,6 @@
 import sys
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 
 # ========== SR1: PROFESSIONAL_BLOGS 新增源 ==========

--- a/backend/tests/test_75_10_e2e_flask.py
+++ b/backend/tests/test_75_10_e2e_flask.py
@@ -8,7 +8,6 @@
 """
 import sys
 import os
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 import logging
 import pytest

--- a/backend/tests/test_75_10_e2e_verification.py
+++ b/backend/tests/test_75_10_e2e_verification.py
@@ -8,7 +8,6 @@ import sys
 import os
 import logging
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 import pytest
 from unittest.mock import patch, MagicMock

--- a/backend/tests/test_75_10_service_lifecycle.py
+++ b/backend/tests/test_75_10_service_lifecycle.py
@@ -6,7 +6,6 @@ TDD: 修复前应失败（红），修复后应通过（绿）。
 """
 import sys
 import os
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 import pytest
 from unittest.mock import patch, MagicMock

--- a/backend/tests/test_context_compressor.py
+++ b/backend/tests/test_context_compressor.py
@@ -7,7 +7,6 @@ import pytest
 from unittest.mock import patch, MagicMock
 
 import sys
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 
 class TestFilterToolResults:

--- a/backend/tests/test_context_guard.py
+++ b/backend/tests/test_context_guard.py
@@ -6,7 +6,6 @@ from unittest.mock import patch, MagicMock
 
 import sys
 import os
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 from utils.context_guard import (
     estimate_tokens,

--- a/backend/tests/test_crawl4ai.py
+++ b/backend/tests/test_crawl4ai.py
@@ -14,7 +14,6 @@ import pytest
 from unittest.mock import MagicMock, patch, AsyncMock
 
 import sys
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 
 # ========== Task 1: LocalMaterialStore ==========

--- a/backend/tests/test_llm_factory.py
+++ b/backend/tests/test_llm_factory.py
@@ -7,7 +7,6 @@ import pytest
 from unittest.mock import patch, MagicMock
 
 import sys
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 
 class TestProviderConfigs:

--- a/backend/tests/test_recursion_budget.py
+++ b/backend/tests/test_recursion_budget.py
@@ -5,7 +5,6 @@ import pytest
 from unittest.mock import MagicMock, patch
 
 import sys, os
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 from services.blog_generator.style_profile import StyleProfile
 

--- a/backend/tests/test_resilient_llm_caller.py
+++ b/backend/tests/test_resilient_llm_caller.py
@@ -7,7 +7,6 @@ import time
 
 import sys
 import os
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 from utils.resilient_llm_caller import (
     is_truncated,

--- a/backend/tests/test_searcher_71.py
+++ b/backend/tests/test_searcher_71.py
@@ -12,7 +12,6 @@ import pytest
 from unittest.mock import MagicMock, patch
 
 import sys, os
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 
 # ========== Task 1: 扩展搜索源 ==========

--- a/backend/tests/test_sogou_search.py
+++ b/backend/tests/test_sogou_search.py
@@ -8,7 +8,6 @@ from unittest.mock import patch, MagicMock
 
 import sys
 import os
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 
 class TestSogouSearchService:

--- a/backend/tests/test_task_queue/conftest.py
+++ b/backend/tests/test_task_queue/conftest.py
@@ -9,14 +9,8 @@ task_queue 测试 — 共享 Fixtures
 - sample_task: 示例 BlogTask
 """
 import asyncio
-import os
-import sys
 import pytest
 import pytest_asyncio
-
-# 将 backend 加入 path
-_backend_dir = os.path.join(os.path.dirname(__file__), '..', '..')
-sys.path.insert(0, _backend_dir)
 
 from services.task_queue.models import (
     BlogTask, BlogGenerationConfig, TriggerConfig, PublishConfig,

--- a/backend/tests/unit/test_context_management_middleware.py
+++ b/backend/tests/unit/test_context_management_middleware.py
@@ -13,7 +13,6 @@ from unittest.mock import MagicMock, patch
 
 # 将 backend 加入 sys.path
 import sys
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
 
 from services.blog_generator.context_management_middleware import (
     ContextManagementMiddleware,

--- a/backend/tests/verify_102_features.py
+++ b/backend/tests/verify_102_features.py
@@ -21,7 +21,6 @@ import sys
 import time
 import traceback
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 PASS = "✅"
 FAIL = "❌"

--- a/docs/architecture/compatibility-cleanup.md
+++ b/docs/architecture/compatibility-cleanup.md
@@ -1,0 +1,26 @@
+# Compatibility Cleanup Audit
+
+Backend tests use the repository's pytest configuration for imports:
+
+```ini
+[pytest]
+pythonpath = .
+```
+
+Test modules must not mutate `sys.path`. An AST architecture test enforces this
+rule for `backend/conftest.py` and every Python file under `backend/tests/`.
+
+## Compatibility Alias Decision
+
+The legacy route and service aliases introduced by the incremental migration are
+not removed in this phase. Repository tests and patch targets still consume
+paths including `routes.*`, `services.llm_service`, `services.task_queue.*`, and
+the previous media, document, and publishing modules.
+
+Removing those aliases now would violate the compatibility window. They may be
+deleted only after downstream callers and legacy tests have migrated, the
+deprecation has been announced, and a repository-wide scan returns no consumers.
+
+Standalone diagnostic scripts and `backend/__init__.py` retain their existing
+path bootstrap behavior because they run outside pytest. Converting those entry
+points requires a separate packaging and invocation migration.


### PR DESCRIPTION
## 改动说明

- 在 `backend/pytest.ini` 中统一配置测试导入根目录。
- 删除 `backend/conftest.py` 和后端测试中的 53 处 `sys.path.insert/append` 修补。
- 将脚本式 E2E 用例改为正式的 `tests.e2e_utils` 包导入。
- 增加 AST 架构规则，阻止测试重新引入 Python 路径修改。
- 审计增量迁移期间保留的旧路由和服务别名，并记录删除条件。

## 兼容性说明

旧别名目前仍被仓库测试、patch 目标及已有调用路径使用，因此本 PR 不直接删除。待调用方全部迁移、完成弃用说明并确认仓库扫描无消费者后，再提交独立清理 PR。

## 验证

- 后端全量测试：1206 passed, 12 skipped
- 前端单元测试：445 passed
- 前端生产构建：通过
- `git diff --check`：通过
- Flask 启动及 `/health`：通过
- Playwright 冒烟：编辑器、生成按钮、主题切换、博客列表路由均通过，页面无 JavaScript 异常

## 致谢

感谢 **freedomgod**（`wwhfree@qq.com`）对原始方案和实现工作的贡献。

Tracks #110
