### PR TITLE
refactor: remove obsolete reviewer client API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the Vibe Blog project will be documented in this file.
 ## 2026-07-25
 
 ### Changed
+- ♻️ **Reviewer 客户端 API 清理** — 删除无生产消费者的旧评估任务、流、列表和详情客户端，仅保留当前 tutorial 工作流。
 - ♻️ **孤立 Blog Store 清理** — 删除无生产消费者的旧 Pinia Blog Store、专用测试及失效的博客列表客户端调用。
 - 🔧 **前端构建产物治理** — 将 `/frontend/dist/` 明确设为仓库级忽略目录，并停止跟踪历史构建文件。
 - ♻️ **低风险僵尸代码清理** — 删除无生产入口、路由、构建或测试引用的 `ResultCard.vue` 顶层组件，并忽略 `/docs/` 目录

--- a/frontend/__tests__/unit/api.test.ts
+++ b/frontend/__tests__/unit/api.test.ts
@@ -22,9 +22,6 @@ import {
   cancelXhsTask,
   publishToXhs,
   generateExplanationVideo,
-  createReviewTask,
-  getReviewList,
-  getReviewDetail,
 } from '@/services/api'
 
 // Mock API responses
@@ -130,10 +127,6 @@ const server = setupServer(
   http.post('/api/xhs/publish', () => HttpResponse.json({ success: true, url: 'https://xiaohongshu.com/123' })),
   http.post('/api/xhs/explanation-video', () => HttpResponse.json({ success: true, video_url: 'https://example.com/video.mp4' })),
 
-  // Reviewer API
-  http.post('/api/reviewer/evaluate', () => HttpResponse.json(mockTaskResponse)),
-  http.get('/api/reviewer/list', () => HttpResponse.json({ success: true, reviews: [] })),
-  http.get('/api/reviewer/:reviewId', () => HttpResponse.json({ success: true, review: {} })),
 )
 
 beforeAll(() => server.listen())
@@ -327,29 +320,6 @@ describe('api.ts', () => {
       })
       expect(result.success).toBe(true)
       expect(result.video_url).toBe('https://example.com/video.mp4')
-    })
-  })
-
-  describe('Reviewer API', () => {
-    it('should create review task', async () => {
-      const result = await createReviewTask({
-        git_url: 'https://github.com/user/repo',
-        enable_search: true,
-      })
-      expect(result.success).toBe(true)
-      expect(result.task_id).toBe('task-123')
-    })
-
-    it('should get review list', async () => {
-      const result = await getReviewList()
-      expect(result.success).toBe(true)
-      expect(result.reviews).toBeDefined()
-    })
-
-    it('should get review detail', async () => {
-      const result = await getReviewDetail('review-123')
-      expect(result.success).toBe(true)
-      expect(result.review).toBeDefined()
     })
   })
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -354,37 +354,3 @@ export async function generateExplanationVideo(params: {
   })
   return response.json()
 }
-
-// ========== 教程评估 API ==========
-
-export interface ReviewerParams {
-  git_url: string
-  enable_search?: boolean
-}
-
-// 创建评估任务
-export async function createReviewTask(params: ReviewerParams): Promise<{ success: boolean; task_id?: string; error?: string }> {
-  const response = await fetch(`${API_BASE}/api/reviewer/evaluate`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(params)
-  })
-  return response.json()
-}
-
-// 创建评估 SSE 连接
-export function createReviewStream(taskId: string): EventSource {
-  return new EventSource(`${API_BASE}/api/reviewer/stream/${taskId}`)
-}
-
-// 获取评估列表
-export async function getReviewList(): Promise<{ success: boolean; reviews?: any[] }> {
-  const response = await fetch(`${API_BASE}/api/reviewer/list`)
-  return response.json()
-}
-
-// 获取评估详情
-export async function getReviewDetail(reviewId: string): Promise<{ success: boolean; review?: any }> {
-  const response = await fetch(`${API_BASE}/api/reviewer/${reviewId}`)
-  return response.json()
-}


### PR DESCRIPTION
## Summary

- remove four obsolete Reviewer client functions and their private parameter type
- remove the corresponding API unit tests and MSW handlers
- preserve Reviewer.vue and its current tutorial, chapter, stream, export, and delete APIs
- leave backend Reviewer routes unchanged
- update CHANGELOG.md

## Verification

- obsolete Reviewer client symbols and endpoint paths: zero matches in frontend
- focused API tests: 27 passed
- uv lock --check: passed
- backend non-LLM: 1206 passed, 12 skipped
- frontend Vitest: 436 passed
- frontend production build: passed
- git diff --check: passed

Refs #136