### PR TITLE
test: stabilize E2E UI contracts and runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the Vibe Blog project will be documented in this file.
 
 ---
 
+## 2026-07-27
+
+### Changed
+- 🔧 **E2E 失败治理设计** — 将 10 个浏览器失败拆分为 UI 测试契约与真实生成预算两个独立 PR，明确退出码、稳定选择器和外部抓取时限的验收标准。
+
+### Tests
+- ✨ **E2E UI 修复计划** — 规划修复 TipTap 选择器、质量评估按钮定位、历史滚动动画和 runner 退出码误报。
+
 ## 2026-07-26
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to the Vibe Blog project will be documented in this file.
 
 ### Tests
 - ✨ **E2E UI 修复计划** — 规划修复 TipTap 选择器、质量评估按钮定位、历史滚动动画和 runner 退出码误报。
+- 🐛 **E2E UI 契约修复** — 更新 TipTap 输入和质量评估按钮选择器，稳定历史滚动点击区域，并让 runner 正确透传 pytest 失败退出码。
 
 ## 2026-07-26
 

--- a/backend/tests/architecture/test_e2e_ui_contracts.py
+++ b/backend/tests/architecture/test_e2e_ui_contracts.py
@@ -1,0 +1,104 @@
+import os
+import re
+import subprocess
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _read(relative_path: str) -> str:
+    return (PROJECT_ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def _css_rule(source: str, selector: str) -> str:
+    match = re.search(rf"{re.escape(selector)}\s*\{{(?P<body>[^}}]*)\}}", source)
+    assert match is not None, f"missing CSS rule: {selector}"
+    return match.group("body")
+
+
+def test_e2e_runner_preserves_pytest_exit_status_through_tee():
+    runner = _read("tests/e2e/tools/run_e2e.sh")
+
+    assert "set -o pipefail" in runner
+    assert 'set +e\nif [ "$SMOKE" = true ]' in runner
+    assert 'fi\nset -e\n\necho ""' in runner
+    assert 'mkdir -p "$SCREENSHOT_DIR" "$LOG_DIR"' in runner
+    assert 'ls -1 "$SCREENSHOT_DIR"/*.png' not in runner
+
+
+def test_e2e_runner_registers_cleanup_for_all_exit_paths():
+    runner = _read("tests/e2e/tools/run_e2e.sh")
+
+    assert "trap cleanup_services EXIT" in runner
+    assert "trap 'exit 130' INT" in runner
+    assert "trap 'exit 143' TERM" in runner
+
+
+def test_e2e_runner_returns_the_failing_pytest_status(tmp_path):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_uv = fake_bin / "uv"
+    fake_uv.write_text(
+        """#!/bin/sh
+case " $* " in
+  *" pytest "*)
+    echo "fake pytest failure"
+    exit 7
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+""",
+        encoding="utf-8",
+    )
+    fake_uv.chmod(0o755)
+
+    fake_lsof = fake_bin / "lsof"
+    fake_lsof.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    fake_lsof.chmod(0o755)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+    env["VIBE_RUNTIME_DIR"] = str(tmp_path / "runtime")
+    result = subprocess.run(
+        ["bash", "tests/e2e/tools/run_e2e.sh", "--test-only", "--smoke"],
+        cwd=PROJECT_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=15,
+        check=False,
+    )
+
+    output = result.stdout + result.stderr
+    assert result.returncode == 7
+    assert "fake pytest failure" in output
+    assert "E2E 测试有失败 (exit code: 7)" in output
+
+
+def test_ui_cases_use_the_shared_tiptap_input_contract():
+    responsive = _read("tests/e2e/test_tc11_responsive.py")
+    error_cases = _read("tests/e2e/test_tc12_error.py")
+
+    for source in (responsive, error_cases):
+        assert "textarea.code-input-textarea" not in source
+        assert "INPUT_SELECTORS" in source
+
+
+def test_quality_dialog_case_selects_the_named_action():
+    quality_cases = _read("tests/e2e/test_tc14_quality_eval.py")
+
+    assert ".card-toolbar button:has(svg)" not in quality_cases
+    assert 'get_by_role("button", name="质量评估")' in quality_cases
+
+
+def test_history_click_target_is_stationary():
+    home = _read("frontend/src/views/Home.vue")
+    click_target = _css_rule(home, ".scroll-hint")
+    animated_arrow = _css_rule(home, ".scroll-hint-arrow")
+
+    assert "animation:" not in click_target
+    assert "z-index:" in click_target
+    assert "animation:" in animated_arrow

--- a/docs/plans/2026-07-27-e2e-failure-remediation-design.md
+++ b/docs/plans/2026-07-27-e2e-failure-remediation-design.md
@@ -1,0 +1,34 @@
+# E2E Failure Remediation Design
+
+## Context
+
+The full E2E run on `origin/main` at `36e430e` collected 42 tests and finished with 32 passed and 10 failed. Seven failures are stale or unstable UI tests. Three failures come from live generation exceeding the test deadline while external deep-scrape providers retry.
+
+Issue #160 tracks the evidence and acceptance criteria.
+
+## Delivery Boundaries
+
+### PR 1: UI E2E contracts and runner correctness
+
+- Make the shell runner preserve pytest's exit status through `tee`.
+- Reuse the shared TipTap-aware input selectors in responsive and validation tests.
+- Select the quality action by a stable accessible contract instead of toolbar position.
+- Keep the history navigation click target stationary by animating its child arrow.
+- Add architecture tests that reject the stale selector and runner patterns.
+
+This PR does not change API, SSE, generation, or persistence behavior.
+
+### PR 2: Live generation budget and completion waits
+
+- Bound external deep scraping by per-request and total deadlines, with a smaller mini preset.
+- Stop waiting on unavailable sources after enough useful material has succeeded.
+- Centralize E2E task completion/history readiness polling.
+- Make TC02, TC15, and TC16 fail at the actual incomplete state instead of navigating to a missing history record.
+
+This PR preserves API payloads, event names, graph ordering, and database schemas.
+
+## Testing Strategy
+
+PR 1 uses a repository contract test as the RED gate, then runs affected Playwright cases, full backend non-LLM tests, frontend Vitest, and production build. PR 2 adds unit tests for deadline/retry policy and polling helpers before changing implementation, then runs focused live E2E and the same static gates.
+
+The full live suite remains evidence-based: its pytest summary and exit code are authoritative, not the runner banner.

--- a/docs/plans/2026-07-27-e2e-ui-cases-implementation.md
+++ b/docs/plans/2026-07-27-e2e-ui-cases-implementation.md
@@ -1,0 +1,66 @@
+# E2E UI Cases Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Repair seven stale/flaky UI E2E cases and make the tracked runner report pytest failures correctly.
+
+**Architecture:** Keep selectors centralized in `backend/tests/e2e_utils.py`, expose the quality action through an accessible button contract, and keep animated decoration separate from click targets. Protect the contracts with a repository-level architecture test.
+
+**Tech Stack:** Python/pytest, Playwright, Vue 3 SFC, Bash, Vitest/Vite
+
+---
+
+### Task 1: Add RED repository contracts
+
+**Files:**
+- Create: `backend/tests/architecture/test_e2e_ui_contracts.py`
+
+**Steps:**
+1. Assert the runner contains `set -o pipefail`.
+2. Assert TC11 and TC12 do not use `textarea.code-input-textarea`.
+3. Assert TC14 does not select the last SVG toolbar button.
+4. Assert the scroll animation is not applied to `.scroll-hint`.
+5. Run `uv run --project backend pytest backend/tests/architecture/test_e2e_ui_contracts.py -q` and verify the expected failures.
+
+### Task 2: Preserve runner exit status
+
+**Files:**
+- Modify: `tests/e2e/tools/run_e2e.sh`
+
+**Steps:**
+1. Replace `set -e` with strict error handling that includes `pipefail`.
+2. Run the architecture contract and verify the runner assertion passes.
+
+### Task 3: Update TipTap-aware E2E input usage
+
+**Files:**
+- Modify: `tests/e2e/test_tc11_responsive.py`
+- Modify: `tests/e2e/test_tc12_error.py`
+
+**Steps:**
+1. Import and use `find_element`, `fill_input`, and `INPUT_SELECTORS`.
+2. Assert the discovered contenteditable editor and generate button are visible/disabled as appropriate.
+3. Run the architecture contract and focused tests.
+
+### Task 4: Stabilize quality action and history click target
+
+**Files:**
+- Modify: `frontend/src/views/Generate.vue`
+- Modify: `frontend/src/views/Home.vue`
+- Modify: `tests/e2e/test_tc14_quality_eval.py`
+
+**Steps:**
+1. Add an accessible label/test contract to the quality action.
+2. Select the action by role/name in TC14.
+3. Move the bounce animation from `.scroll-hint` to `.scroll-hint-arrow`.
+4. Run the architecture contract and focused Playwright cases.
+
+### Task 5: Verify and commit
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+**Steps:**
+1. Record the runner and UI E2E fixes under `2026-07-27`.
+2. Run backend non-LLM tests, frontend tests, build, focused E2E, `git diff --check`, and artifact hygiene checks.
+3. Review the diff, commit, push, and create a PR with `Refs #160`.

--- a/frontend/src/views/Generate.vue
+++ b/frontend/src/views/Generate.vue
@@ -66,7 +66,7 @@
                 </Tooltip>
                 <Tooltip v-if="completedBlogId">
                   <TooltipTrigger as-child>
-                    <Button variant="ghost" size="icon" class="h-8 w-8" :disabled="evaluateLoading" @click="handleEvaluate">
+                    <Button variant="ghost" size="icon" class="h-8 w-8" aria-label="质量评估" :disabled="evaluateLoading" @click="handleEvaluate">
                       <GraduationCap :size="16" />
                     </Button>
                   </TooltipTrigger>

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -1062,6 +1062,7 @@ onUnmounted(() => {
 /* 下滑提示 */
 .scroll-hint {
   position: absolute;
+  z-index: 2;
   bottom: 2rem;
   left: 50%;
   transform: translateX(-50%);
@@ -1073,12 +1074,12 @@ onUnmounted(() => {
   font-family: var(--font-mono);
   font-size: var(--font-size-xs);
   opacity: 0.5;
-  animation: scroll-bounce 2s ease-in-out infinite;
   cursor: pointer;
 }
 
 .scroll-hint-arrow {
   opacity: 0.6;
+  animation: scroll-bounce 2s ease-in-out infinite;
 }
 
 @keyframes scroll-bounce {

--- a/tests/e2e/test_tc11_responsive.py
+++ b/tests/e2e/test_tc11_responsive.py
@@ -3,6 +3,7 @@ TC-11: 响应式布局（P2）
 
 验证：移动端视口下关键元素可见性
 """
+from e2e_utils import find_element, INPUT_SELECTORS
 
 
 def test_mobile_layout(browser, base_url):
@@ -15,7 +16,9 @@ def test_mobile_layout(browser, base_url):
     p.goto(base_url, wait_until="networkidle")
 
     # 输入卡片应可见
-    assert p.locator("textarea.code-input-textarea").is_visible()
+    input_el, _ = find_element(p, INPUT_SELECTORS)
+    assert input_el is not None
+    assert input_el.is_visible()
 
     # 生成按钮应可见
     assert p.locator("button.code-generate-btn").is_visible()
@@ -33,7 +36,9 @@ def test_tablet_layout(browser, base_url):
     p = ctx.new_page()
     p.goto(base_url, wait_until="networkidle")
 
-    assert p.locator("textarea.code-input-textarea").is_visible()
+    input_el, _ = find_element(p, INPUT_SELECTORS)
+    assert input_el is not None
+    assert input_el.is_visible()
     assert p.locator("button.code-generate-btn").is_visible()
 
     p.close()

--- a/tests/e2e/test_tc12_error.py
+++ b/tests/e2e/test_tc12_error.py
@@ -3,7 +3,12 @@ TC-12: 错误处理（P2）
 
 验证：空主题/纯空格时生成按钮 disabled
 """
-from e2e_utils import find_element, GENERATE_BTN_SELECTORS
+from e2e_utils import (
+    find_element,
+    fill_input,
+    GENERATE_BTN_SELECTORS,
+    INPUT_SELECTORS,
+)
 
 
 def test_empty_topic_disabled(page, base_url):
@@ -17,7 +22,9 @@ def test_empty_topic_disabled(page, base_url):
 def test_whitespace_topic_disabled(page, base_url):
     """纯空格主题时生成按钮 disabled"""
     page.goto(base_url, wait_until="networkidle")
-    textarea = page.locator("textarea.code-input-textarea")
-    textarea.fill("   ")
-    gen_btn = page.locator("button.code-generate-btn")
+    input_el, _ = find_element(page, INPUT_SELECTORS)
+    assert input_el is not None
+    fill_input(page, input_el, "   ")
+    gen_btn, _ = find_element(page, GENERATE_BTN_SELECTORS)
+    assert gen_btn is not None
     assert gen_btn.is_disabled()

--- a/tests/e2e/test_tc14_quality_eval.py
+++ b/tests/e2e/test_tc14_quality_eval.py
@@ -188,8 +188,7 @@ class TestQualityDialogUI:
 
     def _click_evaluate_button(self, page):
         """点击评估按钮（GraduationCap 图标按钮）"""
-        # 评估按钮在 .card-toolbar 中，包含 svg 图标，tooltip "质量评估"
-        eval_btn = page.locator('.card-toolbar button:has(svg)').last
+        eval_btn = page.get_by_role("button", name="质量评估")
         eval_btn.wait_for(state="visible", timeout=10000)
         eval_btn.click()
         page.wait_for_timeout(1000)

--- a/tests/e2e/tools/run_e2e.sh
+++ b/tests/e2e/tools/run_e2e.sh
@@ -18,6 +18,7 @@
 # ============================================================
 
 set -e
+set -o pipefail
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -42,6 +43,10 @@ UV_RUN=(uv run --project "$BACKEND_DIR")
 
 BACKEND_PORT=5001
 FRONTEND_PORT=5173
+STARTED_BACKEND=false
+STARTED_FRONTEND=false
+BACKEND_PID=""
+FRONTEND_PID=""
 
 # 解析参数
 RESTART=false
@@ -92,6 +97,29 @@ kill_port() {
     fi
 }
 
+cleanup_services() {
+    local exit_code=$?
+
+    if [ "$STARTED_BACKEND" = true ] || [ "$STARTED_FRONTEND" = true ]; then
+        echo ""
+        echo -e "${YELLOW}清理脚本启动的服务...${NC}"
+        if [ "$STARTED_BACKEND" = true ] && [ -n "$BACKEND_PID" ]; then
+            kill "$BACKEND_PID" 2>/dev/null || true
+            echo "  后端已停止"
+        fi
+        if [ "$STARTED_FRONTEND" = true ] && [ -n "$FRONTEND_PID" ]; then
+            kill "$FRONTEND_PID" 2>/dev/null || true
+            echo "  前端已停止"
+        fi
+    fi
+
+    return "$exit_code"
+}
+
+trap cleanup_services EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
 # ============================================================
 # 主流程
 # ============================================================
@@ -117,9 +145,6 @@ if [ "$TEST_ONLY" = false ]; then
 
     NEED_BACKEND=false
     NEED_FRONTEND=false
-    STARTED_BACKEND=false
-    STARTED_FRONTEND=false
-
     if ! check_port $BACKEND_PORT; then
         NEED_BACKEND=true
         echo -e "${YELLOW}后端未运行，启动中...${NC}"
@@ -166,6 +191,7 @@ echo ""
 echo -e "${BLUE}[Step 2] 准备测试环境${NC}"
 
 # 清理旧截图
+mkdir -p "$SCREENSHOT_DIR" "$LOG_DIR"
 if [ -d "$SCREENSHOT_DIR" ]; then
     OLD_COUNT=$(ls -1 "$SCREENSHOT_DIR" 2>/dev/null | wc -l)
     if [ "$OLD_COUNT" -gt 0 ]; then
@@ -173,7 +199,6 @@ if [ -d "$SCREENSHOT_DIR" ]; then
         rm -f "$SCREENSHOT_DIR"/*.png "$SCREENSHOT_DIR"/*.json
     fi
 fi
-mkdir -p "$SCREENSHOT_DIR"
 
 # 设置环境变量
 export RUN_E2E_TESTS=1
@@ -191,6 +216,7 @@ echo -e "${BLUE}[Step 3] 运行 E2E 测试${NC}"
 
 cd "$PROJECT_ROOT"
 
+set +e
 if [ "$SMOKE" = true ]; then
     echo -e "  运行 smoke 测试 (TC-01 + TC-02)..."
     "${UV_RUN[@]}" pytest tests/e2e/test_tc01_home_load.py tests/e2e/test_tc02_blog_gen.py \
@@ -207,6 +233,7 @@ else
         -v --tb=short $EXTRA_PYTEST_ARGS 2>&1 | tee "$LOG_DIR/e2e_result_$(date +%H%M%S).log"
     TEST_EXIT=$?
 fi
+set -e
 
 echo ""
 
@@ -214,8 +241,8 @@ echo ""
 
 echo -e "${BLUE}[Step 4] 测试结果${NC}"
 
-SCREENSHOT_COUNT=$(ls -1 "$SCREENSHOT_DIR"/*.png 2>/dev/null | wc -l)
-LOG_COUNT=$(ls -1 "$SCREENSHOT_DIR"/*.json 2>/dev/null | wc -l)
+SCREENSHOT_COUNT=$(find "$SCREENSHOT_DIR" -maxdepth 1 -type f -name '*.png' -print | wc -l)
+LOG_COUNT=$(find "$SCREENSHOT_DIR" -maxdepth 1 -type f -name '*.json' -print | wc -l)
 
 echo -e "  截图: ${SCREENSHOT_COUNT} 张 → $SCREENSHOT_DIR"
 echo -e "  日志: ${LOG_COUNT} 个 → $SCREENSHOT_DIR"
@@ -250,15 +277,6 @@ else
     echo -e "${RED}============================================================${NC}"
     echo -e "  查看截图: open $SCREENSHOT_DIR"
     echo -e "  查看日志: ls $LOG_DIR/e2e_result_*.log"
-fi
-
-# ── 清理：如果是脚本启动的服务，停掉 ──
-
-if [ "$STARTED_BACKEND" = true ] || [ "$STARTED_FRONTEND" = true ]; then
-    echo ""
-    echo -e "${YELLOW}清理脚本启动的服务...${NC}"
-    [ "$STARTED_BACKEND" = true ] && [ -n "$BACKEND_PID" ] && kill $BACKEND_PID 2>/dev/null && echo "  后端已停止"
-    [ "$STARTED_FRONTEND" = true ] && [ -n "$FRONTEND_PID" ] && kill $FRONTEND_PID 2>/dev/null && echo "  前端已停止"
 fi
 
 exit $TEST_EXIT


### PR DESCRIPTION
## Summary

- update stale TipTap and quality-evaluation selectors to current UI contracts
- keep the history scroll target stationary and clickable above the footer
- make the E2E runner preserve pytest failures through tee and clean up services on every exit path
- add architecture/behavior regression tests for these contracts

## Verification

- Backend: 1237 passed, 12 skipped
- Frontend: 446 passed
- Frontend build: passed
- Focused browser E2E: 9 passed, 4 skipped (API-dependent quality checks had no stored blog in the fresh runtime)
- Runner contract tests: 6 passed, including forced pytest exit status 7
- bash -n and git diff --check: passed

Refs #160