### PR TITLE
fix: remove Google favicon dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the Vibe Blog project will be documented in this file.
 
 ---
 
+## 2026-07-29
+
+### Fixed
+- 🐛 **进度来源图标** — 搜索与抓取卡片改用本地 Globe 图标，移除 Google favicon 外部请求及其网络超时与来源域名泄露风险。
+
+### Tests
+- ✨ **本地来源图标契约** — 覆盖搜索与抓取卡片的本地图标渲染，并断言不再创建远程 favicon 图片。
+
 ## 2026-07-28
 
 ### Fixed

--- a/frontend/__tests__/integration/components/ProgressDrawer.test.ts
+++ b/frontend/__tests__/integration/components/ProgressDrawer.test.ts
@@ -538,11 +538,13 @@ describe('ProgressDrawer.vue', () => {
       expect(wrapper.text()).toContain('LangGraph 入门')
     })
 
-    it('should render favicon images with correct src', () => {
+    it('should render local source icons without remote favicon images', () => {
       const wrapper = mount(ProgressDrawer, {
         props: { ...defaultProps, expanded: true, progressItems: [searchItem] },
       })
-      expect(wrapper.exists()).toBe(true)
+      expect(wrapper.findAll('[data-testid="source-site-icon"]')).toHaveLength(3)
+      expect(wrapper.findAll('img')).toHaveLength(0)
+      expect(wrapper.html()).not.toContain('google.com/s2/favicons')
     })
 
     it('should render search card links with correct href', () => {
@@ -611,6 +613,15 @@ describe('ProgressDrawer.vue', () => {
         props: { ...defaultProps, expanded: true, progressItems: [crawlItem] },
       })
       expect(wrapper.exists()).toBe(true)
+    })
+
+    it('should render a local source icon without a remote favicon image', () => {
+      const wrapper = mount(ProgressDrawer, {
+        props: { ...defaultProps, expanded: true, progressItems: [crawlItem] },
+      })
+      expect(wrapper.findAll('[data-testid="source-site-icon"]')).toHaveLength(1)
+      expect(wrapper.findAll('img')).toHaveLength(0)
+      expect(wrapper.html()).not.toContain('google.com/s2/favicons')
     })
 
     it('should render content size in KB', () => {

--- a/frontend/src/components/home/ProgressDrawer.vue
+++ b/frontend/src/components/home/ProgressDrawer.vue
@@ -193,7 +193,12 @@
                   :style="{ animationDelay: `${Math.min(ri * 50, 500)}ms` }"
                 >
                   <a class="flex gap-2 h-40 w-40 p-3 bg-accent rounded-xl text-xs text-muted-foreground no-underline overflow-hidden transition-colors hover:bg-muted hover:text-foreground" :href="r.url" target="_blank" rel="noopener">
-                    <img class="shrink-0 mt-0.5 rounded-sm size-4 object-contain" :src="`https://www.google.com/s2/favicons?domain=${r.domain}&sz=16`" :alt="r.domain" />
+                    <Globe2
+                      data-testid="source-site-icon"
+                      :size="16"
+                      class="shrink-0 mt-0.5 text-muted-foreground"
+                      aria-hidden="true"
+                    />
                     <span class="overflow-hidden line-clamp-6 leading-relaxed break-words">{{ r.title }}</span>
                   </a>
                 </li>
@@ -209,7 +214,13 @@
               <ul class="flex flex-wrap gap-4 list-none p-0 m-0">
                 <li class="animate-in fade-in slide-in-from-bottom-2 duration-300">
                   <a class="flex gap-2 h-40 w-40 p-3 bg-accent rounded-xl text-xs text-muted-foreground no-underline overflow-hidden transition-colors hover:bg-muted hover:text-foreground" :href="item.data.url || '#'" target="_blank" rel="noopener">
-                    <img v-if="item.data.url && getHostname(item.data.url)" class="shrink-0 mt-0.5 rounded-sm size-4 object-contain" :src="`https://www.google.com/s2/favicons?domain=${getHostname(item.data.url)}&sz=16`" />
+                    <Globe2
+                      v-if="item.data.url"
+                      data-testid="source-site-icon"
+                      :size="16"
+                      class="shrink-0 mt-0.5 text-muted-foreground"
+                      aria-hidden="true"
+                    />
                     <span class="overflow-hidden line-clamp-6 leading-relaxed break-words">{{ item.data.title || item.data.url || '未知页面' }}</span>
                   </a>
                 </li>
@@ -273,7 +284,7 @@
 
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue'
-import { Square, ChevronRight, ChevronDown, X, Lightbulb, Search, BookOpenText } from 'lucide-vue-next'
+import { Square, ChevronRight, ChevronDown, X, Lightbulb, Search, BookOpenText, Globe2 } from 'lucide-vue-next'
 import { useSmartAutoScroll } from '@/composables/useSmartAutoScroll'
 import { Separator } from '@/components/ui/separator'
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
@@ -396,17 +407,6 @@ const getLogIcon = (type: string) => {
   return icons[type] || '○'
 }
 
-const getHostname = (url: string): string | null => {
-  try {
-    if (typeof URL !== 'undefined') {
-      return new URL(url).hostname
-    }
-    const match = url.match(/^https?:\/\/([^\/]+)/)
-    return match ? match[1] : null
-  } catch {
-    return null
-  }
-}
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Summary

- replace Google favicon requests in search and crawl progress cards with the local Lucide `Globe2` icon
- preserve source links, titles, layout, and accessible link names
- add component contracts that reject remote favicon images

## Verification

- `npm test -- --run __tests__/integration/components/ProgressDrawer.test.ts` - 49 passed
- `npm test -- --run` - 447 passed
- `npm run build` - passed
- `python -m pytest tests/architecture/test_e2e_ui_contracts.py -v` - 6 passed
- repository scan confirms `frontend/src` no longer references `google.com/s2/favicons`

## Post-merge E2E evidence

The first full run on `37d8481` reached TC16's final console assertion and failed only on four Google favicon timeouts (`41 passed, 1 failed`). After this change, TC16 had no favicon or console errors. A second full 42-case run exposed two independent backend/provider issues (`40 passed, 2 failed`): a running task was cleaned before slow generation completed, and an LLM connection failure produced an empty completed history record. Those issues are intentionally outside this UI-only PR and will be handled separately under #160.

Refs #160
