### PR TITLE
chore: ignore local implementation plans

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,8 +115,8 @@ backend/logs/
 *.bak
 *.swp
 
-# 文档目录
-/docs/
+# 本地实施计划
+/docs/plans/
 
 backend/test_*.py
 backend/test_*.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the Vibe Blog project will be documented in this file.
 
 ---
 
+## 2026-07-29
+
+### Changed
+- 🔧 **计划文档忽略范围** — 将 Git 忽略规则从整个 `docs/` 收窄为 `docs/plans/`，保留正式文档的跟踪能力。
+
 ## 2026-07-28
 
 ### Fixed


### PR DESCRIPTION
## Summary

- narrow the untracked documentation ignore rule from all of `docs/` to `docs/plans/`
- keep local implementation plans out of Git while allowing new formal documentation elsewhere under `docs/`

## Verification

- `git check-ignore -v docs/plans/example.md` - matched `/docs/plans/`
- `git check-ignore -v docs/example.md` - no match
- `python -m pytest tests/architecture/test_repository_hygiene.py -v` - 2 passed
- `git diff --check` - passed
