### PR TITLE
feat: add structured output contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to the Vibe Blog project will be documented in this file.
 
 ---
 
+## 2026-07-30
+
+### Added
+- ✨ **结构化输出契约** — 新增统一 Pydantic 解析入口、decode/validation 错误分类、严格/兼容模式及显式单次修复策略。
+
+### Changed
+- ♻️ **输出 Schema 边界** — 将稳定的 Agent 输出模型迁至独立 `schemas/outputs.py`，并保留原有导入身份兼容。
+
+### Tests
+- ✨ **结构化解析契约测试** — 覆盖 JSON/fence、Mapping/BaseModel、类型校验、截断输入、有限修复、多围栏拒绝及错误与日志脱敏。
+
 ## 2026-07-29
 
 ### Changed

--- a/backend/services/blog_generator/__init__.py
+++ b/backend/services/blog_generator/__init__.py
@@ -9,6 +9,14 @@ from importlib import import_module
 
 _EXPORTS = {
     "BlogGenerator": ("services.blog_generator.generator", "BlogGenerator"),
+    "StructuredOutputError": (
+        "services.blog_generator.structured_output",
+        "StructuredOutputError",
+    ),
+    "parse_structured_output": (
+        "services.blog_generator.structured_output",
+        "parse_structured_output",
+    ),
     "SearchService": ("services.blog_generator.services.search_service", "SearchService"),
     "init_search_service": (
         "services.blog_generator.services.search_service",

--- a/backend/services/blog_generator/schemas/__init__.py
+++ b/backend/services/blog_generator/schemas/__init__.py
@@ -2,18 +2,26 @@
 数据模型模块 - Pydantic 模型和 TypedDict 定义
 """
 
-from .state import (
-    SharedState,
-    SectionOutline,
-    SectionContent,
+from .outputs import (
+    AudienceAnalysis,
+    BlogOutline,
     CodeBlock,
     ImageResource,
-    VaguePoint,
+    InformationArchitecture,
+    InstructionalAnalysis,
+    KnowledgeGap,
+    LearningObjective,
     QuestionResult,
     ReviewIssue,
-    BlogOutline,
-    KnowledgeGap,
     SearchHistoryItem,
+    SearchResult,
+    SectionContent,
+    SectionOutline,
+    VaguePoint,
+    VerbatimDataItem,
+)
+from .state import (
+    SharedState,
     create_initial_state,
     get_max_search_count,
 )
@@ -30,6 +38,12 @@ __all__ = [
     'BlogOutline',
     'KnowledgeGap',
     'SearchHistoryItem',
+    'LearningObjective',
+    'AudienceAnalysis',
+    'VerbatimDataItem',
+    'InstructionalAnalysis',
+    'InformationArchitecture',
+    'SearchResult',
     'create_initial_state',
     'get_max_search_count',
 ]

--- a/backend/services/blog_generator/schemas/outputs.py
+++ b/backend/services/blog_generator/schemas/outputs.py
@@ -1,0 +1,169 @@
+"""Stable Pydantic models for structured Agent outputs."""
+
+from typing import List, Literal, Optional
+
+from pydantic import BaseModel, Field
+
+
+class SectionOutline(BaseModel):
+    """章节大纲"""
+    id: str
+    title: str
+    key_concept: str
+    content_outline: List[str] = Field(default_factory=list)
+    image_type: Literal["flowchart", "architecture", "sequence", "comparison", "chart", "none"] = "none"
+    image_description: str = ""
+    code_blocks: int = 0
+    has_output_block: bool = False
+    key_quote: str = ""
+
+
+class BlogOutline(BaseModel):
+    """博客大纲"""
+    title: str
+    subtitle: str
+    reading_time: int
+    article_type: Literal["problem-solution", "tutorial", "comparison"]
+    introduction: str
+    core_value: str
+    table_of_contents: List[str] = Field(default_factory=list)
+    sections: List[SectionOutline] = Field(default_factory=list)
+    conclusion_summary_points: List[str] = Field(default_factory=list)
+    conclusion_next_steps: str = ""
+    reference_links: List[str] = Field(default_factory=list)
+
+
+class SectionContent(BaseModel):
+    """章节内容"""
+    id: str
+    title: str
+    content: str
+    image_ids: List[str] = Field(default_factory=list)
+    code_ids: List[str] = Field(default_factory=list)
+
+
+class CodeBlock(BaseModel):
+    """代码块"""
+    id: str
+    code: str
+    output: str
+    explanation: str
+    language: str = "python"
+
+
+class ImageResource(BaseModel):
+    """图片资源"""
+    id: str
+    render_method: Literal["mermaid", "ai_image", "matplotlib"]
+    content: str
+    rendered_path: Optional[str] = None
+    caption: str
+
+
+class VaguePoint(BaseModel):
+    """模糊点 (Questioner 输出)"""
+    location: str
+    issue: str
+    question: str
+    suggestion: str
+
+
+class QuestionResult(BaseModel):
+    """追问结果"""
+    section_id: str
+    is_detailed_enough: bool
+    vague_points: List[VaguePoint] = Field(default_factory=list)
+    depth_score: int
+
+
+class ReviewIssue(BaseModel):
+    """审核问题"""
+    section_id: str
+    issue_type: Literal["completeness", "logic", "verbatim_violation", "learning_objective_gap"]
+    severity: Literal["high", "medium", "low"]
+    description: str
+    suggestion: str
+    original_value: Optional[str] = None
+    found_value: Optional[str] = None
+
+
+class LearningObjective(BaseModel):
+    """学习目标"""
+    type: Literal["primary", "secondary", "tertiary"]
+    objective: str
+
+
+class AudienceAnalysis(BaseModel):
+    """受众分析"""
+    knowledge_level: Literal["beginner", "intermediate", "advanced"]
+    reading_purpose: str
+    expected_outcome: str
+
+
+class VerbatimDataItem(BaseModel):
+    """Verbatim 数据项（需要原样保留的数据）"""
+    type: Literal["statistic", "quote", "term"]
+    value: str
+    context: Optional[str] = None
+    source: Optional[str] = None
+    definition: Optional[str] = None
+
+
+class InstructionalAnalysis(BaseModel):
+    """教学设计分析（Researcher 输出）"""
+    learning_objectives: List[LearningObjective] = Field(default_factory=list)
+    audience: Optional[AudienceAnalysis] = None
+    content_type: Literal["tutorial", "concept", "comparison", "problem-solving", "overview"] = "tutorial"
+    verbatim_data: List[VerbatimDataItem] = Field(default_factory=list)
+
+
+class InformationArchitecture(BaseModel):
+    """信息架构（Planner 输出）"""
+    structure_type: Literal["linear-progression", "hierarchical", "comparison", "problem-solving"]
+    learning_objectives_mapping: List[dict] = Field(default_factory=list)
+
+
+class SearchResult(BaseModel):
+    """搜索结果"""
+    title: str
+    url: str
+    content: str
+    source: str = ""
+    publish_date: str = ""
+    relevance_score: float = 0.0
+
+
+class KnowledgeGap(BaseModel):
+    """知识空白点"""
+    gap_type: Literal["missing_data", "vague_concept", "no_example"]
+    description: str
+    suggested_query: str
+    section_id: Optional[str] = None
+
+
+class SearchHistoryItem(BaseModel):
+    """搜索历史记录"""
+    round: int
+    queries: List[str]
+    results_count: int
+    gaps_addressed: List[str]
+
+
+__all__ = [
+    "AudienceAnalysis",
+    "BlogOutline",
+    "CodeBlock",
+    "ImageResource",
+    "InformationArchitecture",
+    "InstructionalAnalysis",
+    "KnowledgeGap",
+    "LearningObjective",
+    "QuestionResult",
+    "ReviewIssue",
+    "SearchHistoryItem",
+    "SearchResult",
+    "SectionContent",
+    "SectionOutline",
+    "VaguePoint",
+    "VerbatimDataItem",
+]

--- a/backend/services/blog_generator/schemas/state.py
+++ b/backend/services/blog_generator/schemas/state.py
@@ -5,151 +5,25 @@
 import os
 import uuid
 from typing import TypedDict, List, Optional, Literal
-from pydantic import BaseModel, Field
 
-
-class SectionOutline(BaseModel):
-    """章节大纲"""
-    id: str
-    title: str
-    key_concept: str
-    content_outline: List[str] = Field(default_factory=list)
-    image_type: Literal["flowchart", "architecture", "sequence", "comparison", "chart", "none"] = "none"
-    image_description: str = ""
-    code_blocks: int = 0
-    has_output_block: bool = False
-    key_quote: str = ""
-
-
-class BlogOutline(BaseModel):
-    """博客大纲"""
-    title: str
-    subtitle: str
-    reading_time: int
-    article_type: Literal["problem-solution", "tutorial", "comparison"]
-    introduction: str
-    core_value: str
-    table_of_contents: List[str] = Field(default_factory=list)
-    sections: List[SectionOutline] = Field(default_factory=list)
-    conclusion_summary_points: List[str] = Field(default_factory=list)
-    conclusion_next_steps: str = ""
-    reference_links: List[str] = Field(default_factory=list)
-
-
-class SectionContent(BaseModel):
-    """章节内容"""
-    id: str
-    title: str
-    content: str  # Markdown 内容
-    image_ids: List[str] = Field(default_factory=list)
-    code_ids: List[str] = Field(default_factory=list)
-
-
-class CodeBlock(BaseModel):
-    """代码块"""
-    id: str
-    code: str
-    output: str
-    explanation: str
-    language: str = "python"
-
-
-class ImageResource(BaseModel):
-    """图片资源"""
-    id: str
-    render_method: Literal["mermaid", "ai_image", "matplotlib"]
-    content: str  # Mermaid 代码 或 AI Prompt 或 Python 代码
-    rendered_path: Optional[str] = None  # 渲染后的图片路径
-    caption: str
-
-
-class VaguePoint(BaseModel):
-    """模糊点 (Questioner 输出)"""
-    location: str  # 段落位置或引用文本
-    issue: str  # 问题描述
-    question: str  # 追问问题
-    suggestion: str  # 建议补充的内容类型
-
-
-class QuestionResult(BaseModel):
-    """追问结果"""
-    section_id: str
-    is_detailed_enough: bool
-    vague_points: List[VaguePoint] = Field(default_factory=list)
-    depth_score: int  # 0-100
-
-
-class ReviewIssue(BaseModel):
-    """审核问题"""
-    section_id: str
-    issue_type: Literal["completeness", "logic", "verbatim_violation", "learning_objective_gap"]
-    severity: Literal["high", "medium", "low"]
-    description: str
-    suggestion: str
-    original_value: Optional[str] = None  # 仅 verbatim_violation 类型需要
-    found_value: Optional[str] = None  # 仅 verbatim_violation 类型需要
-
-
-class LearningObjective(BaseModel):
-    """学习目标"""
-    type: Literal["primary", "secondary", "tertiary"]
-    objective: str
-
-
-class AudienceAnalysis(BaseModel):
-    """受众分析"""
-    knowledge_level: Literal["beginner", "intermediate", "advanced"]
-    reading_purpose: str
-    expected_outcome: str
-
-
-class VerbatimDataItem(BaseModel):
-    """Verbatim 数据项（需要原样保留的数据）"""
-    type: Literal["statistic", "quote", "term"]
-    value: str
-    context: Optional[str] = None
-    source: Optional[str] = None
-    definition: Optional[str] = None  # 仅 term 类型需要
-
-
-class InstructionalAnalysis(BaseModel):
-    """教学设计分析（Researcher 输出）"""
-    learning_objectives: List[LearningObjective] = Field(default_factory=list)
-    audience: Optional[AudienceAnalysis] = None
-    content_type: Literal["tutorial", "concept", "comparison", "problem-solving", "overview"] = "tutorial"
-    verbatim_data: List[VerbatimDataItem] = Field(default_factory=list)
-
-
-class InformationArchitecture(BaseModel):
-    """信息架构（Planner 输出）"""
-    structure_type: Literal["linear-progression", "hierarchical", "comparison", "problem-solving"]
-    learning_objectives_mapping: List[dict] = Field(default_factory=list)  # [{"objective": "...", "supported_by_sections": ["section_1"]}]
-
-
-class SearchResult(BaseModel):
-    """搜索结果"""
-    title: str
-    url: str
-    content: str
-    source: str = ""
-    publish_date: str = ""
-    relevance_score: float = 0.0
-
-
-class KnowledgeGap(BaseModel):
-    """知识空白点"""
-    gap_type: Literal["missing_data", "vague_concept", "no_example"]
-    description: str
-    suggested_query: str
-    section_id: Optional[str] = None
-
-
-class SearchHistoryItem(BaseModel):
-    """搜索历史记录"""
-    round: int  # 第几轮搜索
-    queries: List[str]  # 本轮搜索的查询
-    results_count: int  # 结果数量
-    gaps_addressed: List[str]  # 本轮解决的知识空白
+from .outputs import (
+    AudienceAnalysis,
+    BlogOutline,
+    CodeBlock,
+    ImageResource,
+    InformationArchitecture,
+    InstructionalAnalysis,
+    KnowledgeGap,
+    LearningObjective,
+    QuestionResult,
+    ReviewIssue,
+    SearchHistoryItem,
+    SearchResult,
+    SectionContent,
+    SectionOutline,
+    VaguePoint,
+    VerbatimDataItem,
+)
 
 
 class SharedState(TypedDict):

--- a/backend/services/blog_generator/structured_output.py
+++ b/backend/services/blog_generator/structured_output.py
@@ -1,0 +1,215 @@
+"""Typed parsing boundary for LLM structured output."""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from collections.abc import Callable, Mapping
+from typing import Any, Literal, TypeVar
+
+from pydantic import BaseModel, ValidationError
+
+
+logger = logging.getLogger(__name__)
+
+ModelT = TypeVar("ModelT", bound=BaseModel)
+ParseMode = Literal["strict", "compat"]
+RepairStrategy = Callable[[str], str | Mapping[str, Any] | BaseModel]
+
+_WHOLE_FENCE_RE = re.compile(
+    r"\A\s*```(?:json)?[ \t]*\r?\n(?P<body>.*?)\r?\n?```\s*\Z",
+    re.IGNORECASE | re.DOTALL,
+)
+_ANY_FENCE_RE = re.compile(
+    r"```(?P<label>[^\r\n`]*)\r?\n(?P<body>.*?)\r?\n?```",
+    re.DOTALL,
+)
+_SENSITIVE_MARKER_RE = re.compile(
+    r"(?i)(?:\b(?:api[_-]?key|authorization|access[_-]?token|token|secret|password)\b"
+    r"|\b(?:basic|bearer)\s+\S+)"
+)
+_TOKEN_RE = re.compile(r"\b(?:sk|pk|AIza)-?[A-Za-z0-9_-]{8,}\b")
+_PREVIEW_LIMIT = 240
+
+__all__ = ["StructuredOutputError", "parse_structured_output"]
+
+
+class StructuredOutputError(ValueError):
+    """A structured-output failure with a stable decode/validation category."""
+
+    def __init__(
+        self,
+        kind: Literal["decode", "validation"],
+        model_name: str,
+        details: list[dict[str, Any]],
+    ) -> None:
+        self.kind = kind
+        self.model_name = model_name
+        self.details = details
+        super().__init__(f"Structured output {kind} failed for {model_name}")
+
+
+class _DecodeFailure(Exception):
+    def __init__(self, details: list[dict[str, Any]]) -> None:
+        self.details = details
+
+
+def parse_structured_output(
+    model: type[ModelT],
+    raw: str | Mapping[str, Any] | BaseModel,
+    *,
+    mode: ParseMode = "strict",
+    repair: RepairStrategy | None = None,
+) -> ModelT:
+    """Decode and validate one LLM response as ``model``.
+
+    Strict mode accepts pure JSON or a response fully wrapped in one JSON fence
+    and disables Pydantic coercion. Compatibility mode additionally permits one
+    fenced block surrounded by prose and uses normal Pydantic coercion. A repair
+    strategy is opt-in and receives at most one attempt after a decode failure.
+    """
+    if mode not in {"strict", "compat"}:
+        raise ValueError(f"Unsupported structured output mode: {mode}")
+    if not isinstance(model, type) or not issubclass(model, BaseModel):
+        raise TypeError("model must be a Pydantic BaseModel class")
+
+    model_name = model.__name__
+    try:
+        payload = _coerce_input(raw, mode)
+    except _DecodeFailure as first_failure:
+        if repair is None or not isinstance(raw, str):
+            _raise_decode_error(model_name, raw, first_failure.details)
+
+        try:
+            repaired = repair(raw)
+            payload = _coerce_input(repaired, mode)
+        except _DecodeFailure as repair_failure:
+            _raise_decode_error(model_name, raw, repair_failure.details)
+        except Exception as exc:
+            _raise_decode_error(
+                model_name,
+                raw,
+                [{"type": "repair_error", "exception": type(exc).__name__}],
+            )
+
+    try:
+        return model.model_validate(payload, strict=mode == "strict")
+    except ValidationError as exc:
+        details = _sanitize_validation_errors(exc)
+        _log_failure("validation", model_name, raw)
+        raise StructuredOutputError("validation", model_name, details) from None
+
+
+def _coerce_input(
+    raw: str | Mapping[str, Any] | BaseModel,
+    mode: ParseMode,
+) -> Any:
+    if isinstance(raw, BaseModel):
+        return raw.model_dump(mode="python")
+    if isinstance(raw, Mapping):
+        return dict(raw)
+    if not isinstance(raw, str):
+        raise _DecodeFailure(
+            [{"type": "unsupported_input", "input_type": type(raw).__name__}]
+        )
+
+    candidate = _extract_json_text(raw, mode)
+    if not candidate:
+        raise _DecodeFailure([{"type": "empty_input"}])
+    try:
+        return json.loads(candidate)
+    except json.JSONDecodeError as exc:
+        raise _DecodeFailure(
+            [
+                {
+                    "type": "json_decode",
+                    "line": exc.lineno,
+                    "column": exc.colno,
+                    "position": exc.pos,
+                }
+            ]
+        ) from None
+
+
+def _extract_json_text(raw: str, mode: ParseMode) -> str:
+    stripped = raw.strip()
+    fenced_blocks = list(_ANY_FENCE_RE.finditer(stripped))
+    if mode == "compat" and len(fenced_blocks) > 1:
+        raise _DecodeFailure(
+            [{"type": "ambiguous_fenced_output", "count": len(fenced_blocks)}]
+        )
+
+    whole_fence = _WHOLE_FENCE_RE.fullmatch(stripped)
+    if whole_fence and len(fenced_blocks) == 1:
+        return whole_fence.group("body").strip()
+    if mode == "strict":
+        return stripped
+
+    if len(fenced_blocks) == 1:
+        fenced_block = fenced_blocks[0]
+        if fenced_block.group("label").strip().lower() in {"", "json"}:
+            return fenced_block.group("body").strip()
+        raise _DecodeFailure([{"type": "unsupported_fenced_output"}])
+    return stripped
+
+
+def _raise_decode_error(
+    model_name: str,
+    raw: Any,
+    details: list[dict[str, Any]],
+) -> None:
+    _log_failure("decode", model_name, raw)
+    raise StructuredOutputError("decode", model_name, details) from None
+
+
+def _sanitize_validation_errors(exc: ValidationError) -> list[dict[str, Any]]:
+    details = []
+    for error in exc.errors(include_url=False, include_input=False):
+        location = [
+            "<field>"
+            if isinstance(part, str)
+            else "<index>"
+            if isinstance(part, int)
+            else "<location>"
+            for part in error.get("loc", ())
+        ]
+        details.append(
+            {
+                "type": str(error.get("type", "validation_error")),
+                "loc": location,
+                "message": "Field validation failed",
+            }
+        )
+    return details
+
+
+def _log_failure(kind: str, model_name: str, raw: Any) -> None:
+    logger.warning(
+        "Structured output %s failed: model=%s preview=%s",
+        kind,
+        model_name,
+        _safe_preview(raw),
+    )
+
+
+def _safe_preview(raw: Any) -> str:
+    if isinstance(raw, BaseModel):
+        raw = raw.model_dump(mode="json")
+    if isinstance(raw, Mapping):
+        try:
+            text = json.dumps(dict(raw), ensure_ascii=False, default=str)
+        except Exception:
+            text = f"<{type(raw).__name__}>"
+    elif isinstance(raw, str):
+        text = raw
+    else:
+        text = f"<{type(raw).__name__}>"
+
+    if _SENSITIVE_MARKER_RE.search(text) or _TOKEN_RE.search(text):
+        return "[REDACTED]"
+
+    text = re.sub(r"\s+", " ", text).strip()
+    if len(text) > _PREVIEW_LIMIT:
+        return f"{text[:_PREVIEW_LIMIT]}..."
+    return text

--- a/backend/tests/unit/test_output_schema_compat.py
+++ b/backend/tests/unit/test_output_schema_compat.py
@@ -1,0 +1,53 @@
+import pytest
+
+from services.blog_generator import schemas
+from services.blog_generator.schemas import outputs
+from services.blog_generator.schemas import state
+
+
+OUTPUT_MODEL_NAMES = (
+    "SectionOutline",
+    "BlogOutline",
+    "SectionContent",
+    "CodeBlock",
+    "ImageResource",
+    "VaguePoint",
+    "QuestionResult",
+    "ReviewIssue",
+    "LearningObjective",
+    "AudienceAnalysis",
+    "VerbatimDataItem",
+    "InstructionalAnalysis",
+    "InformationArchitecture",
+    "SearchResult",
+    "KnowledgeGap",
+    "SearchHistoryItem",
+)
+
+LEGACY_PACKAGE_EXPORTS = (
+    "SectionOutline",
+    "SectionContent",
+    "CodeBlock",
+    "ImageResource",
+    "VaguePoint",
+    "QuestionResult",
+    "ReviewIssue",
+    "BlogOutline",
+    "KnowledgeGap",
+    "SearchHistoryItem",
+)
+
+
+@pytest.mark.parametrize("model_name", OUTPUT_MODEL_NAMES)
+def test_state_reexports_output_model_identity(model_name):
+    assert getattr(state, model_name) is getattr(outputs, model_name)
+
+
+@pytest.mark.parametrize("model_name", LEGACY_PACKAGE_EXPORTS)
+def test_package_keeps_legacy_output_model_identity(model_name):
+    assert getattr(schemas, model_name) is getattr(outputs, model_name)
+
+
+def test_shared_state_remains_owned_by_state_module():
+    assert schemas.SharedState is state.SharedState
+    assert not hasattr(outputs, "SharedState")

--- a/backend/tests/unit/test_structured_output.py
+++ b/backend/tests/unit/test_structured_output.py
@@ -1,0 +1,273 @@
+import json
+import logging
+from types import MappingProxyType
+
+import pytest
+from pydantic import BaseModel, RootModel, field_validator
+
+from services import blog_generator
+from services.blog_generator.structured_output import (
+    StructuredOutputError,
+    parse_structured_output,
+)
+
+
+class ExampleOutput(BaseModel):
+    name: str
+    count: int
+
+
+class CompatibleSource(BaseModel):
+    name: str
+    count: int
+
+
+class SecretRejectingOutput(BaseModel):
+    value: str
+
+    @field_validator("value")
+    @classmethod
+    def reject_value(cls, value):
+        raise ValueError(f"rejected secret value {value}")
+
+
+class IntegerDictionaryOutput(RootModel[dict[str, int]]):
+    pass
+
+
+def test_blog_generator_package_exposes_structured_output_contract():
+    assert blog_generator.parse_structured_output is parse_structured_output
+    assert blog_generator.StructuredOutputError is StructuredOutputError
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        '{"name": "alpha", "count": 2}',
+        '```json\n{"name": "alpha", "count": 2}\n```',
+        '```JSON\n{"name": "alpha", "count": 2}\n```',
+        MappingProxyType({"name": "alpha", "count": 2}),
+        CompatibleSource(name="alpha", count=2),
+    ],
+)
+def test_parse_structured_output_accepts_supported_inputs(raw):
+    result = parse_structured_output(ExampleOutput, raw)
+
+    assert result == ExampleOutput(name="alpha", count=2)
+
+
+def test_strict_mode_rejects_surrounding_text():
+    raw = 'Result:\n```json\n{"name": "alpha", "count": 2}\n```\nDone.'
+
+    with pytest.raises(StructuredOutputError) as raised:
+        parse_structured_output(ExampleOutput, raw)
+
+    assert raised.value.kind == "decode"
+
+
+def test_compat_mode_accepts_one_fenced_block_with_surrounding_text():
+    raw = 'Result:\n```json\n{"name": "alpha", "count": "2"}\n```\nDone.'
+
+    result = parse_structured_output(ExampleOutput, raw, mode="compat")
+
+    assert result == ExampleOutput(name="alpha", count=2)
+
+
+def test_compat_mode_rejects_multiple_fenced_blocks():
+    raw = (
+        '```json\n{"name": "alpha", "count": 1}\n```\n'
+        '```json\n{"name": "beta", "count": 2}\n```'
+    )
+
+    with pytest.raises(StructuredOutputError) as raised:
+        parse_structured_output(ExampleOutput, raw, mode="compat")
+
+    assert raised.value.kind == "decode"
+
+
+def test_compat_mode_counts_non_json_fenced_blocks_as_ambiguous():
+    raw = (
+        '```json\n{"name": "alpha", "count": 1}\n```\n'
+        '```python\nprint("ignored")\n```'
+    )
+
+    with pytest.raises(StructuredOutputError) as raised:
+        parse_structured_output(ExampleOutput, raw, mode="compat")
+
+    assert raised.value.kind == "decode"
+    assert raised.value.details == [
+        {"type": "ambiguous_fenced_output", "count": 2}
+    ]
+
+
+def test_strict_mode_disables_pydantic_type_coercion():
+    with pytest.raises(StructuredOutputError) as raised:
+        parse_structured_output(
+            ExampleOutput,
+            {"name": "alpha", "count": "2"},
+        )
+
+    assert raised.value.kind == "validation"
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "",
+        "   ",
+        "not JSON",
+        '{"name": "truncated", "count": 2',
+        'prefix {"name": "alpha", "count": 2} suffix',
+        None,
+        ["unsupported"],
+    ],
+)
+def test_decode_errors_are_classified(raw):
+    with pytest.raises(StructuredOutputError) as raised:
+        parse_structured_output(ExampleOutput, raw)
+
+    error = raised.value
+    assert error.kind == "decode"
+    assert error.model_name == "ExampleOutput"
+    assert error.details
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        {"name": "missing count"},
+        {"name": "wrong type", "count": {"nested": True}},
+    ],
+)
+def test_validation_errors_are_classified_without_input_values(raw):
+    with pytest.raises(StructuredOutputError) as raised:
+        parse_structured_output(ExampleOutput, raw)
+
+    error = raised.value
+    assert error.kind == "validation"
+    assert error.model_name == "ExampleOutput"
+    assert error.details
+    assert all("input" not in detail for detail in error.details)
+
+
+def test_custom_validation_error_details_are_json_safe_and_secret_free():
+    secret = "TOP-SECRET-CONTENT"
+
+    with pytest.raises(StructuredOutputError) as raised:
+        parse_structured_output(SecretRejectingOutput, {"value": secret})
+
+    serialized_details = json.dumps(raised.value.details)
+    assert secret not in serialized_details
+    assert raised.value.details == [
+        {
+            "type": "value_error",
+            "loc": ["<field>"],
+            "message": "Field validation failed",
+        }
+    ]
+
+
+def test_validation_error_location_does_not_expose_dynamic_input_key(caplog):
+    secret = "TOP-SECRET-DICT-KEY"
+
+    with caplog.at_level(
+        logging.WARNING,
+        logger="services.blog_generator.structured_output",
+    ):
+        with pytest.raises(StructuredOutputError) as raised:
+            parse_structured_output(IntegerDictionaryOutput, {secret: "bad"})
+
+    serialized_details = json.dumps(raised.value.details)
+    assert secret not in serialized_details
+    assert secret not in caplog.text
+    assert raised.value.details == [
+        {
+            "type": "int_type",
+            "loc": ["<field>"],
+            "message": "Field validation failed",
+        }
+    ]
+
+
+def test_explicit_repair_is_attempted_once_after_decode_failure():
+    calls = []
+
+    def close_object(raw):
+        calls.append(raw)
+        return f"{raw}}}"
+
+    result = parse_structured_output(
+        ExampleOutput,
+        '{"name": "repaired", "count": 3',
+        repair=close_object,
+    )
+
+    assert result == ExampleOutput(name="repaired", count=3)
+    assert calls == ['{"name": "repaired", "count": 3']
+
+
+def test_failed_repair_is_not_retried():
+    calls = []
+
+    def still_invalid(raw):
+        calls.append(raw)
+        return raw
+
+    with pytest.raises(StructuredOutputError) as raised:
+        parse_structured_output(
+            ExampleOutput,
+            '{"name": "truncated"',
+            repair=still_invalid,
+        )
+
+    assert raised.value.kind == "decode"
+    assert len(calls) == 1
+
+
+def test_error_log_uses_bounded_redacted_preview(caplog):
+    secret = "sk-super-secret-token-value"
+    raw = (
+        '{"api_key": "'
+        + secret
+        + '", "name": "'
+        + ("private-user-content-" * 30)
+    )
+
+    with caplog.at_level(
+        logging.WARNING,
+        logger="services.blog_generator.structured_output",
+    ):
+        with pytest.raises(StructuredOutputError) as raised:
+            parse_structured_output(ExampleOutput, raw)
+
+    log_text = caplog.text
+    assert secret not in log_text
+    assert "[REDACTED]" in log_text
+    assert len(log_text) < 600
+    assert secret not in str(raised.value)
+
+
+@pytest.mark.parametrize(
+    ("raw", "secret"),
+    [
+        (
+            "Authorization: Basic dXNlcjpwYXNzd29yZA==",
+            "dXNlcjpwYXNzd29yZA==",
+        ),
+        ("password=plain-text-password", "plain-text-password"),
+        (
+            '{"api_key":"prefix\\\"still-secret-value", broken',
+            "still-secret-value",
+        ),
+    ],
+)
+def test_error_log_omits_malformed_sensitive_preview(caplog, raw, secret):
+    with caplog.at_level(
+        logging.WARNING,
+        logger="services.blog_generator.structured_output",
+    ):
+        with pytest.raises(StructuredOutputError):
+            parse_structured_output(ExampleOutput, raw)
+
+    assert secret not in caplog.text
+    assert "preview=[REDACTED]" in caplog.text


### PR DESCRIPTION
## Summary

- add a shared `parse_structured_output` boundary with strict/compat modes, stable decode/validation errors, and an opt-in single repair attempt
- keep failure diagnostics JSON-safe and input-free while conservatively redacting sensitive previews
- move stable Agent output models to `schemas/outputs.py` while preserving existing import identities

## Scope

This is PR1 for Issue #159. It establishes the structured-output infrastructure only. No Agent call sites, BlogService/DatabaseService code, or frontend consumers are migrated in this PR.

## Test Plan

- `python -m pytest tests/unit/test_structured_output.py tests/unit/test_output_schema_compat.py tests/test_blog_generator.py tests/integration/test_agents.py tests/test_background_investigation.py tests/test_knowledge_gap.py tests/unit/test_api_import_compat.py -q` (`96 passed, 1 skipped`)
- `python -m pytest tests/ -q` (`1321 passed, 12 skipped`)
- `python -m compileall -q services/blog_generator tests/unit/test_structured_output.py tests/unit/test_output_schema_compat.py`
- `git diff --check`

Refs #159
