### PR TITLE
refactor: migrate structured output consumers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,12 @@ All notable changes to the Vibe Blog project will be documented in this file.
 
 ### Changed
 - ♻️ **输出 Schema 边界** — 将稳定的 Agent 输出模型迁至独立 `schemas/outputs.py`，并保留原有导入身份兼容。
+- ♻️ **结构化输出消费者迁移** — 将 12 个生成 Agent 与 6 个研究服务统一迁至共享 Pydantic 解析边界，删除重复 JSON 提取器并保留既有重试与降级语义。
+- 🔧 **Planner 截断修复边界** — 将思考前缀与截断 JSON 修复收口为 Planner 专用显式策略，其他消费者仅使用有限的旧格式兼容修复。
 
 ### Tests
 - ✨ **结构化解析契约测试** — 覆盖 JSON/fence、Mapping/BaseModel、类型校验、截断输入、有限修复、多围栏拒绝及错误与日志脱敏。
+- ✨ **结构化消费者回归契约** — 覆盖畸形嵌套输出、原有 fallback、渐进重试与 Planner 截断场景，并用 AST 守卫禁止 18 个目标模块重新引入私有解析器或 `json.loads`。
 
 ## 2026-07-29
 

--- a/backend/services/blog_generator/agents/artist.py
+++ b/backend/services/blog_generator/agents/artist.py
@@ -2,7 +2,6 @@
 Artist Agent - 配图生成
 """
 
-import json
 import logging
 import os
 import re
@@ -10,6 +9,12 @@ from typing import Dict, Any, List
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from ..prompts import get_prompt_manager
+from ..schemas.outputs import (
+    ArtistGenerationOutput,
+    ContentEvaluationOutput,
+    MissingDiagramsOutput,
+)
+from ..structured_output import parse_structured_output, repair_legacy_json
 from ...image_service import get_image_service, AspectRatio, ImageSize
 from ..image_enhancement import ImageEnhancementPipeline
 
@@ -33,28 +38,6 @@ IMAGE_BUDGET = {
     'custom': 8,
 }
 
-
-def _extract_json(text: str) -> dict:
-    """从 LLM 响应中提取 JSON（处理 markdown 包裹）"""
-    text = text.strip()
-    if '```json' in text:
-        start = text.find('```json') + 7
-        end = text.find('```', start)
-        if end != -1:
-            text = text[start:end].strip()
-        else:
-            text = text[start:].strip()
-    elif '```' in text:
-        start = text.find('```') + 3
-        end = text.find('```', start)
-        if end != -1:
-            text = text[start:end].strip()
-        else:
-            text = text[start:].strip()
-    try:
-        return json.loads(text)
-    except json.JSONDecodeError:
-        return json.loads(text, strict=False)
 
 def _get_observe_decorator():
     """获取 Langfuse observe 装饰器，未启用时返回空装饰器"""
@@ -356,7 +339,12 @@ class ArtistAgent:
                 response_format={"type": "json_object"}
             )
             
-            result = _extract_json(response)
+            result = parse_structured_output(
+                ArtistGenerationOutput,
+                response,
+                mode="compat",
+                repair=repair_legacy_json,
+            ).model_dump(mode="json")
             content = result.get("content", "")
             render_method = result.get("render_method", "mermaid")
             caption = result.get("caption", "")
@@ -441,13 +429,17 @@ class ArtistAgent:
             if not response or not response.strip():
                 return default_result
 
-            result = _extract_json(response)
+            result = parse_structured_output(
+                ContentEvaluationOutput,
+                response,
+                mode="compat",
+                repair=repair_legacy_json,
+            ).model_dump(mode="json")
             scores = result.get("scores", default_result["scores"])
             score_values = [v for v in scores.values() if isinstance(v, (int, float))]
-            overall = result.get(
-                "overall_quality",
-                round(sum(score_values) / max(len(score_values), 1), 1),
-            )
+            overall = result.get("overall_quality")
+            if overall is None:
+                overall = round(sum(score_values) / max(len(score_values), 1), 1)
             return {
                 "scores": scores,
                 "overall_quality": overall,
@@ -646,7 +638,12 @@ class ArtistAgent:
                     response_format={"type": "json_object"}
                 )
                 
-                result = _extract_json(response)
+                result = parse_structured_output(
+                    MissingDiagramsOutput,
+                    response,
+                    mode="compat",
+                    repair=repair_legacy_json,
+                ).model_dump(mode="json")
                 needs_diagrams = result.get('needs_diagrams', [])
                 
                 # 每个章节最多补充 1 个图表

--- a/backend/services/blog_generator/agents/coder.py
+++ b/backend/services/blog_generator/agents/coder.py
@@ -2,7 +2,6 @@
 Coder Agent - 代码生成
 """
 
-import json
 import logging
 import os
 import re
@@ -10,6 +9,8 @@ from typing import Dict, Any, List
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from ..prompts import get_prompt_manager
+from ..schemas.outputs import CodeGenerationOutput
+from ..structured_output import parse_structured_output, repair_legacy_json
 
 # 从环境变量读取并行配置，默认为 3
 MAX_WORKERS = int(os.environ.get('BLOG_GENERATOR_MAX_WORKERS', '3'))
@@ -103,7 +104,12 @@ class CoderAgent:
                 response_format={"type": "json_object"}
             )
             
-            result = json.loads(response)
+            result = parse_structured_output(
+                CodeGenerationOutput,
+                response,
+                mode="compat",
+                repair=repair_legacy_json,
+            ).model_dump(mode="json")
             return {
                 "code": result.get("code_block", ""),
                 "output": result.get("output_block", ""),

--- a/backend/services/blog_generator/agents/factcheck.py
+++ b/backend/services/blog_generator/agents/factcheck.py
@@ -5,39 +5,17 @@ FactCheck Agent - 事实核查
 位于 reviewer/revision 之后、humanizer 之前。
 """
 
-import json
 import logging
 import os
 from typing import Dict, Any, List
 
 from ..prompts import get_prompt_manager
+from ..schemas.outputs import FactCheckOutput
+from ..structured_output import parse_structured_output, repair_legacy_json
 
 logger = logging.getLogger(__name__)
 
 VERDICT_MAP = {"S": "SUPPORTED", "C": "CONTRADICTED", "U": "UNVERIFIED"}
-
-
-def _extract_json(text: str) -> dict:
-    """从 LLM 响应中提取 JSON"""
-    text = text.strip()
-    if '```json' in text:
-        start = text.find('```json') + 7
-        end = text.find('```', start)
-        if end != -1:
-            text = text[start:end].strip()
-        else:
-            text = text[start:].strip()
-    elif '```' in text:
-        start = text.find('```') + 3
-        end = text.find('```', start)
-        if end != -1:
-            text = text[start:end].strip()
-        else:
-            text = text[start:].strip()
-    try:
-        return json.loads(text)
-    except json.JSONDecodeError:
-        return json.loads(text, strict=False)
 
 
 def _build_content(sections: List[dict]) -> str:
@@ -128,7 +106,12 @@ class FactCheckAgent:
         )
         if not response or not response.strip():
             raise ValueError("LLM 事实核查返回空响应")
-        raw = _extract_json(response)
+        raw = parse_structured_output(
+            FactCheckOutput,
+            response,
+            mode="compat",
+            repair=repair_legacy_json,
+        ).model_dump(mode="json")
         return _normalize_report(raw)
 
     def run(self, state: Dict[str, Any]) -> Dict[str, Any]:

--- a/backend/services/blog_generator/agents/humanizer.py
+++ b/backend/services/blog_generator/agents/humanizer.py
@@ -5,7 +5,6 @@ Humanizer Agent - 去除 AI 写作痕迹
 两步流程：先评分（轻量），评分低于阈值再改写（重量）。
 """
 
-import json
 import logging
 import os
 import re
@@ -14,6 +13,8 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Dict, Any
 
 from ..prompts import get_prompt_manager
+from ..schemas.outputs import HumanizerRewriteOutput, HumanizerScoreOutput
+from ..structured_output import parse_structured_output, repair_legacy_json
 
 logger = logging.getLogger(__name__)
 
@@ -23,48 +24,6 @@ MAX_WORKERS = int(os.getenv('HUMANIZER_MAX_WORKERS', '4'))
 def _extract_source_placeholders(text: str) -> set:
     """提取文本中所有 {source_NNN} 占位符"""
     return set(re.findall(r'\{source_\d+\}', text))
-
-
-def _extract_json(text: str) -> dict:
-    """从 LLM 响应中提取 JSON（处理 markdown 代码块、转义和截断问题）"""
-    text = text.strip()
-    if not text:
-        raise ValueError("LLM 返回空内容，无法解析 JSON")
-    # 提取 markdown 代码块中的 JSON
-    if '```json' in text:
-        start = text.find('```json') + 7
-        end = text.find('```', start)
-        if end != -1:
-            text = text[start:end].strip()
-    elif '```' in text:
-        start = text.find('```') + 3
-        end = text.find('```', start)
-        if end != -1:
-            text = text[start:end].strip()
-    # 如果提取后为空，尝试用正则找最外层 {...}
-    if not text:
-        raise ValueError("LLM 返回内容中未找到有效 JSON")
-
-    # 多轮尝试解析
-    for attempt_fn in [
-        lambda t: json.loads(t),
-        lambda t: json.loads(t, strict=False),
-        lambda t: json.loads(re.sub(r'(?<!\\)\\(?!["\\/bfnrtu])', r'\\\\', t), strict=False),
-    ]:
-        try:
-            return attempt_fn(text)
-        except json.JSONDecodeError:
-            continue
-
-    # 最后尝试：用正则提取最外层 {...} 块（应对 LLM 在 JSON 前后输出额外文本）
-    brace_match = re.search(r'\{[\s\S]*\}', text)
-    if brace_match:
-        try:
-            return json.loads(brace_match.group(), strict=False)
-        except json.JSONDecodeError:
-            pass
-
-    raise json.JSONDecodeError("所有解析策略均失败", text, 0)
 
 
 class HumanizerAgent:
@@ -101,7 +60,12 @@ class HumanizerAgent:
         )
         if not response:
             raise ValueError("LLM 评分返回空响应")
-        return _extract_json(response)
+        return parse_structured_output(
+            HumanizerScoreOutput,
+            response,
+            mode="compat",
+            repair=repair_legacy_json,
+        ).model_dump(mode="json")
 
     def _rewrite_section(self, content: str, audience_adaptation: str) -> Dict[str, Any]:
         """改写：输出 diff 替换列表（含重试）"""
@@ -121,8 +85,13 @@ class HumanizerAgent:
                 )
                 if not response or not response.strip():
                     raise ValueError("LLM 改写返回空响应")
-                return _extract_json(response)
-            except (json.JSONDecodeError, ValueError) as e:
+                return parse_structured_output(
+                    HumanizerRewriteOutput,
+                    response,
+                    mode="compat",
+                    repair=repair_legacy_json,
+                ).model_dump(mode="json")
+            except ValueError as e:
                 last_err = e
                 resp_preview = repr(response[:200]) if response else "(None)"
                 logger.warning(

--- a/backend/services/blog_generator/agents/planner.py
+++ b/backend/services/blog_generator/agents/planner.py
@@ -2,12 +2,12 @@
 Planner Agent - 大纲规划
 """
 
-import json
 import logging
-import re
 from typing import Dict, Any
 
 from ..prompts import get_prompt_manager
+from ..schemas.outputs import PlannerOutlineOutput
+from ..structured_output import parse_structured_output, repair_planner_json
 
 logger = logging.getLogger(__name__)
 
@@ -120,53 +120,14 @@ class PlannerAgent:
                     response_format={"type": "json_object"}
                 )
             
-            # 解析 JSON（可能包含 markdown 代码块或思考文本）
             if not response:
                 raise ValueError("LLM 返回空响应")
-            response_text = response.strip()
-            if '```json' in response_text:
-                start = response_text.find('```json') + 7
-                end = response_text.find('```', start)
-                if end != -1:
-                    response_text = response_text[start:end].strip()
-                else:
-                    # 流式模式下可能缺少结尾 ```
-                    response_text = response_text[start:].strip()
-            elif '```' in response_text:
-                start = response_text.find('```') + 3
-                end = response_text.find('```', start)
-                if end != -1:
-                    response_text = response_text[start:end].strip()
-                else:
-                    response_text = response_text[start:].strip()
-
-            # 如果响应包含思考文本（非 JSON），提取第一个 JSON 对象
-            if response_text and not response_text.startswith('{'):
-                json_start = response_text.find('{')
-                if json_start > 0:
-                    logger.info(f"[Planner] 跳过 {json_start} 字符的思考文本，提取 JSON")
-                    response_text = response_text[json_start:]
-
-            # 尝试修复截断的 JSON（流式模式常见问题）
-            try:
-                outline = json.loads(response_text)
-            except json.JSONDecodeError:
-                # 尝试 strict=False
-                try:
-                    outline = json.loads(response_text, strict=False)
-                except json.JSONDecodeError as e:
-                    # 尝试补全截断的 JSON
-                    repaired = self._repair_truncated_json(response_text)
-                    if repaired:
-                        outline = json.loads(repaired)
-                    else:
-                        raise e
-            
-            # 验证必要字段
-            required_fields = ['title', 'sections']
-            for field in required_fields:
-                if field not in outline:
-                    raise ValueError(f"大纲缺少必要字段: {field}")
+            outline = parse_structured_output(
+                PlannerOutlineOutput,
+                response,
+                mode="compat",
+                repair=repair_planner_json,
+            ).model_dump(mode="json")
             
             # 为每个章节添加 ID (如果没有) 和新字段默认值
             for i, section in enumerate(outline.get('sections', [])):
@@ -186,79 +147,9 @@ class PlannerAgent:
 
             return outline
             
-        except json.JSONDecodeError as e:
-            logger.error(f"大纲 JSON 解析失败: {e}")
-            raise ValueError(f"大纲生成失败: JSON 解析错误")
         except Exception as e:
             logger.error(f"大纲生成失败: {e}")
             raise
-    
-    @staticmethod
-    def _repair_truncated_json(text: str) -> str:
-        """尝试修复截断的 JSON（补全缺失的括号和引号）
-
-        策略：逐步从末尾回退，每次删除最后一个不完整的元素，
-        然后补全所有未闭合的括号。最多尝试 20 次。
-        """
-        open_braces = text.count('{') - text.count('}')
-        open_brackets = text.count('[') - text.count(']')
-
-        if open_braces <= 0 and open_brackets <= 0:
-            return ""
-
-        repaired = text.rstrip()
-
-        for attempt in range(20):
-            candidate = repaired.rstrip().rstrip(',')
-
-            # 检查是否在字符串中间（未闭合的引号）
-            in_string = False
-            escaped = False
-            for ch in candidate:
-                if escaped:
-                    escaped = False
-                    continue
-                if ch == '\\':
-                    escaped = True
-                    continue
-                if ch == '"':
-                    in_string = not in_string
-
-            if in_string:
-                candidate += '"'
-
-            # 检查末尾是否是不完整的 key-value（如 "key": 没有值）
-            stripped = candidate.rstrip()
-            if stripped.endswith(':'):
-                candidate = stripped + ' ""'
-            elif re.search(r':\s*$', stripped):
-                candidate = stripped + '""'
-
-            ob = candidate.count('{') - candidate.count('}')
-            ol = candidate.count('[') - candidate.count(']')
-            candidate += ']' * max(0, ol)
-            candidate += '}' * max(0, ob)
-
-            try:
-                json.loads(candidate)
-                logger.warning(f"[Planner] JSON 截断已修复 (attempt {attempt + 1})")
-                return candidate
-            except json.JSONDecodeError:
-                pass
-
-            # 回退策略：删除最后一个不完整的元素
-            last_comma = repaired.rfind(',')
-            last_open_brace = repaired.rfind('{')
-            last_open_bracket = repaired.rfind('[')
-            cutpoint = max(last_comma, last_open_brace, last_open_bracket)
-            if cutpoint <= 0:
-                return ""
-            if cutpoint == last_comma:
-                repaired = repaired[:cutpoint]
-            else:
-                repaired = repaired[:cutpoint + 1]
-
-        return ""
 
     def run(self, state: Dict[str, Any], on_stream: callable = None) -> Dict[str, Any]:
         """

--- a/backend/services/blog_generator/agents/questioner.py
+++ b/backend/services/blog_generator/agents/questioner.py
@@ -2,13 +2,14 @@
 Questioner Agent - 追问深化
 """
 
-import json
 import logging
 import os
 from typing import Dict, Any, List
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from ..prompts import get_prompt_manager
+from ..schemas.outputs import ContentEvaluationOutput, DepthCheckOutput
+from ..structured_output import parse_structured_output, repair_legacy_json
 
 # 从环境变量读取并行配置，默认为 3
 MAX_WORKERS = int(os.environ.get('BLOG_GENERATOR_MAX_WORKERS', '3'))
@@ -96,20 +97,18 @@ class QuestionerAgent:
                     "vague_points": []
                 }
             
-            result = json.loads(response)
+            result = parse_structured_output(
+                DepthCheckOutput,
+                response,
+                mode="compat",
+                repair=repair_legacy_json,
+            ).model_dump(mode="json")
             return {
                 "is_detailed_enough": result.get("is_detailed_enough", True),
                 "depth_score": result.get("depth_score", 80),
                 "vague_points": result.get("vague_points", [])
             }
             
-        except json.JSONDecodeError as e:
-            logger.warning(f"深度检查 JSON 解析失败: {e}，响应内容: {response[:200] if response else '空'}，默认通过")
-            return {
-                "is_detailed_enough": True,
-                "depth_score": 80,
-                "vague_points": []
-            }
         except Exception as e:
             logger.error(f"深度检查失败: {e}")
             # 默认通过
@@ -174,14 +173,18 @@ class QuestionerAgent:
                 logger.warning("段落评估返回空响应，使用默认分数")
                 return default_result
 
-            result = json.loads(response)
+            result = parse_structured_output(
+                ContentEvaluationOutput,
+                response,
+                mode="compat",
+                repair=repair_legacy_json,
+            ).model_dump(mode="json")
             scores = result.get("scores", default_result["scores"])
             # 计算 overall_quality（如果 LLM 没返回）
             score_values = [v for v in scores.values() if isinstance(v, (int, float))]
-            overall = result.get(
-                "overall_quality",
-                round(sum(score_values) / max(len(score_values), 1), 1),
-            )
+            overall = result.get("overall_quality")
+            if overall is None:
+                overall = round(sum(score_values) / max(len(score_values), 1), 1)
 
             eval_result = {
                 "scores": scores,
@@ -192,9 +195,6 @@ class QuestionerAgent:
 
             return eval_result
 
-        except json.JSONDecodeError as e:
-            logger.warning(f"段落评估 JSON 解析失败: {e}")
-            return default_result
         except Exception as e:
             logger.error(f"段落评估失败: {e}")
             return default_result

--- a/backend/services/blog_generator/agents/researcher.py
+++ b/backend/services/blog_generator/agents/researcher.py
@@ -11,7 +11,14 @@ from typing import Dict, Any, List, Optional
 from urllib.parse import urlparse
 
 from ..prompts import get_prompt_manager
+from ..schemas.outputs import (
+    GapAnalysisOutput,
+    QueryListOutput,
+    ResearchSummaryOutput,
+    SourceDistillationOutput,
+)
 from ..services.smart_search_service import get_smart_search_service, init_smart_search_service
+from ..structured_output import parse_structured_output, repair_legacy_json
 from ..utils.cache_utils import get_cache_manager
 
 logger = logging.getLogger(__name__)
@@ -181,13 +188,16 @@ class ResearcherAgent:
                 response_format={"type": "json_object"}
             )
             
-            queries = json.loads(response)
-            if isinstance(queries, list):
-                # 确保原始 topic 作为第一个 query（防止 LLM 改写主题）
-                if queries and topic.lower() not in queries[0].lower():
-                    queries.insert(0, topic)
-                return queries
-            return default_queries
+            queries = parse_structured_output(
+                QueryListOutput,
+                response,
+                mode="compat",
+                repair=repair_legacy_json,
+            ).root
+            # 确保原始 topic 作为第一个 query（防止 LLM 改写主题）
+            if queries and topic.lower() not in queries[0].lower():
+                queries.insert(0, topic)
+            return queries
             
         except Exception as e:
             logger.warning(f"生成搜索查询失败: {e}，使用默认查询")
@@ -410,22 +420,12 @@ class ResearcherAgent:
                 response_format={"type": "json_object"}
             )
 
-            # 提取 JSON（处理 markdown 代码块）
-            json_str = response.strip()
-            if '```json' in json_str:
-                start = json_str.find('```json') + 7
-                end = json_str.find('```', start)
-                json_str = json_str[start:end].strip() if end != -1 else json_str[start:].strip()
-            elif '```' in json_str:
-                start = json_str.find('```') + 3
-                end = json_str.find('```', start)
-                json_str = json_str[start:end].strip() if end != -1 else json_str[start:].strip()
-
-            # 尝试解析 JSON
-            try:
-                result = json.loads(json_str)
-            except json.JSONDecodeError:
-                result = json.loads(json_str, strict=False)
+            result = parse_structured_output(
+                ResearchSummaryOutput,
+                response,
+                mode="compat",
+                repair=repair_legacy_json,
+            ).model_dump(mode="json")
             key_concepts = result.get("key_concepts", [])
 
             # 调试：打印实际返回内容
@@ -473,8 +473,6 @@ class ResearcherAgent:
 
             return summary_result
 
-        except json.JSONDecodeError as e:
-            logger.error(f"JSON 解析失败: {e}, 响应内容: {response[:500] if response else 'None'}")
         except Exception as e:
             logger.error(f"整理搜索结果失败: {e}")
 
@@ -533,21 +531,12 @@ class ResearcherAgent:
                 response_format={"type": "json_object"}
             )
 
-            # 提取 JSON
-            json_str = response.strip()
-            if '```json' in json_str:
-                json_str = json_str.split('```json')[1].split('```')[0].strip()
-            elif '```' in json_str:
-                json_str = json_str.split('```')[1].split('```')[0].strip()
-
-            result = json.loads(json_str)
-
-            # 确保必要字段存在
-            result.setdefault('sources', [])
-            result.setdefault('common_themes', [])
-            result.setdefault('contradictions', [])
-            result.setdefault('material_by_type',
-                              {"concepts": [], "cases": [], "data": [], "comparisons": []})
+            result = parse_structured_output(
+                SourceDistillationOutput,
+                response,
+                mode="compat",
+                repair=repair_legacy_json,
+            ).model_dump(mode="json")
 
             logger.info(f"🔬 深度提炼完成: {len(result['sources'])} 条素材, "
                         f"{len(result['common_themes'])} 个共同主题, "
@@ -615,19 +604,12 @@ class ResearcherAgent:
                 response_format={"type": "json_object"}
             )
 
-            # 提取 JSON
-            json_str = response.strip()
-            if '```json' in json_str:
-                json_str = json_str.split('```json')[1].split('```')[0].strip()
-            elif '```' in json_str:
-                json_str = json_str.split('```')[1].split('```')[0].strip()
-
-            result = json.loads(json_str)
-
-            # 确保必要字段存在
-            result.setdefault('content_gaps', [])
-            result.setdefault('unique_angles', [])
-            result.setdefault('writing_recommendations', {})
+            result = parse_structured_output(
+                GapAnalysisOutput,
+                response,
+                mode="compat",
+                repair=repair_legacy_json,
+            ).model_dump(mode="json")
 
             logger.info(f"🔍 缺口分析完成: {len(result['content_gaps'])} 个缺口, "
                         f"{len(result['unique_angles'])} 个独特角度")
@@ -804,7 +786,7 @@ class ResearcherAgent:
         ]
         
         # 4. 更新 Instructional Design 相关状态（新增）
-        instructional_analysis = summary.get('instructional_analysis', {})
+        instructional_analysis = summary.get('instructional_analysis') or {}
         state['instructional_analysis'] = instructional_analysis
         state['learning_objectives'] = instructional_analysis.get('learning_objectives', [])
         state['verbatim_data'] = instructional_analysis.get('verbatim_data', [])

--- a/backend/services/blog_generator/agents/reviewer.py
+++ b/backend/services/blog_generator/agents/reviewer.py
@@ -6,36 +6,14 @@ Reviewer Agent - 质量审核（精简版）
 一致性 → ThreadChecker + VoiceChecker。
 """
 
-import json
 import logging
 from typing import Dict, Any
 
 from ..prompts import get_prompt_manager
+from ..schemas.outputs import ReviewerOutput
+from ..structured_output import parse_structured_output, repair_legacy_json
 
 logger = logging.getLogger(__name__)
-
-
-def _extract_json(text: str) -> dict:
-    """从 LLM 响应中提取 JSON（处理 markdown 包裹）"""
-    text = text.strip()
-    if '```json' in text:
-        start = text.find('```json') + 7
-        end = text.find('```', start)
-        if end != -1:
-            text = text[start:end].strip()
-        else:
-            text = text[start:].strip()
-    elif '```' in text:
-        start = text.find('```') + 3
-        end = text.find('```', start)
-        if end != -1:
-            text = text[start:end].strip()
-        else:
-            text = text[start:].strip()
-    try:
-        return json.loads(text)
-    except json.JSONDecodeError:
-        return json.loads(text, strict=False)
 
 
 class ReviewerAgent:
@@ -80,7 +58,12 @@ class ReviewerAgent:
                 response_format={"type": "json_object"}
             )
 
-            result = _extract_json(response)
+            result = parse_structured_output(
+                ReviewerOutput,
+                response,
+                mode="compat",
+                repair=repair_legacy_json,
+            ).model_dump(mode="json")
 
             score = result.get("score", 80)
             issues = result.get("issues", [])

--- a/backend/services/blog_generator/agents/search_coordinator.py
+++ b/backend/services/blog_generator/agents/search_coordinator.py
@@ -3,13 +3,14 @@ SearchCoordinator Agent - 搜索协调器
 负责管理多轮搜索、检测知识空白、执行细化搜索
 """
 
-import json
 import logging
 import os
 from typing import Dict, Any, List, Optional
 
 from ..prompts import get_prompt_manager
+from ..schemas.outputs import KnowledgeGapsOutput
 from ..schemas.state import get_max_search_count
+from ..structured_output import parse_structured_output, repair_legacy_json
 
 logger = logging.getLogger(__name__)
 
@@ -88,7 +89,12 @@ class SearchCoordinator:
                 response_format={"type": "json_object"}
             )
             
-            result = json.loads(response)
+            result = parse_structured_output(
+                KnowledgeGapsOutput,
+                response,
+                mode="compat",
+                repair=repair_legacy_json,
+            ).model_dump(mode="json")
             gaps = result.get('gaps', [])
             
             logger.info(f"检测到 {len(gaps)} 个知识空白")

--- a/backend/services/blog_generator/agents/summary_generator.py
+++ b/backend/services/blog_generator/agents/summary_generator.py
@@ -8,36 +8,15 @@ SummaryGenerator Agent - 博客导读 + SEO 关键词生成
   - Meta Description（150 字以内）
 """
 
-import json
 import logging
 from typing import Dict, Any
 
 from ..prompts import get_prompt_manager
+from ..schemas.outputs import SummaryOutput
+from ..structured_output import parse_structured_output, repair_legacy_json
 
 logger = logging.getLogger(__name__)
 
-
-def _extract_json(text: str) -> dict:
-    """从 LLM 响应中提取 JSON"""
-    text = text.strip()
-    if '```json' in text:
-        start = text.find('```json') + 7
-        end = text.find('```', start)
-        if end != -1:
-            text = text[start:end].strip()
-        else:
-            text = text[start:].strip()
-    elif '```' in text:
-        start = text.find('```') + 3
-        end = text.find('```', start)
-        if end != -1:
-            text = text[start:end].strip()
-        else:
-            text = text[start:].strip()
-    try:
-        return json.loads(text)
-    except json.JSONDecodeError:
-        return json.loads(text, strict=False)
 
 class SummaryGeneratorAgent:
     """博客导读 + SEO 关键词生成 Agent"""
@@ -60,7 +39,12 @@ class SummaryGeneratorAgent:
         )
         if not response or not response.strip():
             raise ValueError("LLM 摘要生成返回空响应")
-        return _extract_json(response)
+        return parse_structured_output(
+            SummaryOutput,
+            response,
+            mode="compat",
+            repair=repair_legacy_json,
+        ).model_dump(mode="json")
 
     def run(self, state: Dict[str, Any]) -> Dict[str, Any]:
         """执行摘要生成并写入 state"""

--- a/backend/services/blog_generator/agents/thread_checker.py
+++ b/backend/services/blog_generator/agents/thread_checker.py
@@ -5,32 +5,14 @@ ThreadChecker Agent - 叙事一致性检查
 检查维度：承诺兑现、叙事流覆盖、核心问题回答、事实一致性、术语一致性、过渡自然度。
 """
 
-import json
 import logging
 from typing import Dict, Any, List
 
 from ..prompts import get_prompt_manager
+from ..schemas.outputs import ThreadCheckOutput
+from ..structured_output import parse_structured_output, repair_legacy_json
 
 logger = logging.getLogger(__name__)
-
-
-def _extract_json(text: str) -> dict:
-    """从 LLM 响应中提取 JSON"""
-    text = text.strip()
-    if '```json' in text:
-        start = text.find('```json') + 7
-        end = text.find('```', start)
-        if end != -1:
-            text = text[start:end].strip()
-    elif '```' in text:
-        start = text.find('```') + 3
-        end = text.find('```', start)
-        if end != -1:
-            text = text[start:end].strip()
-    try:
-        return json.loads(text)
-    except json.JSONDecodeError:
-        return json.loads(text, strict=False)
 
 
 def _build_document(sections: List[dict]) -> str:
@@ -85,7 +67,12 @@ class ThreadCheckerAgent:
         )
         if not response:
             raise ValueError("LLM 叙事一致性检查返回空响应")
-        return _extract_json(response)
+        return parse_structured_output(
+            ThreadCheckOutput,
+            response,
+            mode="compat",
+            repair=repair_legacy_json,
+        ).model_dump(mode="json")
 
     def run(self, state: Dict[str, Any]) -> Dict[str, Any]:
         """执行检查并写入 state"""

--- a/backend/services/blog_generator/agents/voice_checker.py
+++ b/backend/services/blog_generator/agents/voice_checker.py
@@ -5,32 +5,14 @@ VoiceChecker Agent - 语气统一检查
 检查维度：语气一致性、人称一致性、正式度一致性、自称一致性、高频词检测、句式多样性。
 """
 
-import json
 import logging
 from typing import Dict, Any, List
 
 from ..prompts import get_prompt_manager
+from ..schemas.outputs import VoiceCheckOutput
+from ..structured_output import parse_structured_output, repair_legacy_json
 
 logger = logging.getLogger(__name__)
-
-
-def _extract_json(text: str) -> dict:
-    """从 LLM 响应中提取 JSON"""
-    text = text.strip()
-    if '```json' in text:
-        start = text.find('```json') + 7
-        end = text.find('```', start)
-        if end != -1:
-            text = text[start:end].strip()
-    elif '```' in text:
-        start = text.find('```') + 3
-        end = text.find('```', start)
-        if end != -1:
-            text = text[start:end].strip()
-    try:
-        return json.loads(text)
-    except json.JSONDecodeError:
-        return json.loads(text, strict=False)
 
 
 def _build_document(sections: List[dict]) -> str:
@@ -69,7 +51,12 @@ class VoiceCheckerAgent:
         )
         if not response:
             raise ValueError("LLM 语气统一检查返回空响应")
-        return _extract_json(response)
+        return parse_structured_output(
+            VoiceCheckOutput,
+            response,
+            mode="compat",
+            repair=repair_legacy_json,
+        ).model_dump(mode="json")
 
     def run(self, state: Dict[str, Any]) -> Dict[str, Any]:
         """执行检查并写入 state"""

--- a/backend/services/blog_generator/schemas/outputs.py
+++ b/backend/services/blog_generator/schemas/outputs.py
@@ -1,8 +1,8 @@
 """Stable Pydantic models for structured Agent outputs."""
 
-from typing import List, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field, RootModel, model_validator
 
 
 class SectionOutline(BaseModel):
@@ -149,21 +149,322 @@ class SearchHistoryItem(BaseModel):
     gaps_addressed: List[str]
 
 
+class ArtistGenerationOutput(BaseModel):
+    render_method: Literal["mermaid", "ai_image", "matplotlib"]
+    content: str
+    caption: str
+    style_description: str = ""
+
+
+class ContentEvaluationOutput(BaseModel):
+    scores: Dict[str, float]
+    overall_quality: Optional[float] = None
+    specific_issues: List[str]
+    improvement_suggestions: List[str]
+
+
+class MissingDiagram(BaseModel):
+    location: str = ""
+    diagram_type: str
+    description: str
+    context: str
+
+
+class MissingDiagramsOutput(BaseModel):
+    needs_diagrams: List[MissingDiagram]
+
+
+class FactCheckClaim(BaseModel):
+    id: int
+    text: str
+    sid: str
+    v: Literal["S", "C", "U"]
+
+
+class FactCheckFix(BaseModel):
+    sid: str
+    old: str
+    new: str
+
+
+class FactCheckOutput(BaseModel):
+    score: int = Field(ge=1, le=5)
+    claims: List[FactCheckClaim]
+    fixes: List[FactCheckFix]
+
+
+class HumanizerScoreValues(BaseModel):
+    directness: int = Field(ge=1, le=10)
+    rhythm: int = Field(ge=1, le=10)
+    trust: int = Field(ge=1, le=10)
+    authenticity: int = Field(ge=1, le=10)
+    conciseness: int = Field(ge=1, le=10)
+    total: int = Field(ge=5, le=50)
+
+
+class HumanizerScoreOutput(BaseModel):
+    score: HumanizerScoreValues
+    issues_summary: str
+
+
+class TextReplacement(BaseModel):
+    old: str
+    new: str
+
+
+class HumanizerRewriteOutput(BaseModel):
+    replacements: List[TextReplacement]
+
+
+class ReviewerOutput(BaseModel):
+    score: int = Field(ge=0, le=100)
+    approved: Optional[bool] = None
+    issues: List[ReviewIssue]
+    summary: str
+
+
+class SummaryOutput(BaseModel):
+    tldr: str
+    seo_keywords: List[str]
+    social_summary: str
+    meta_description: str
+
+
+class ConsistencyIssue(BaseModel):
+    check_type: str
+    severity: Literal["high", "medium", "low"]
+    section_id: str
+    description: str
+    suggestion: str
+
+
+class ThreadCheckOutput(BaseModel):
+    overall_coherence: int = Field(ge=1, le=5)
+    issues: List[ConsistencyIssue]
+    summary: str
+
+
+class VoiceProfile(BaseModel):
+    target_tone: str
+    target_formality: str
+    target_person: str
+
+
+class ChapterVoice(BaseModel):
+    section_id: str
+    tone: str
+    formality: str
+    dominant_person: str
+
+
+class VoiceCheckOutput(BaseModel):
+    voice_profile: VoiceProfile
+    chapter_voice_map: List[ChapterVoice]
+    issues: List[ConsistencyIssue]
+    summary: str
+
+
+class CodeGenerationOutput(BaseModel):
+    code_block: str
+    output_block: str
+    explanation: str
+
+
+class DepthVaguePoint(BaseModel):
+    location: str
+    question: str
+    suggestion: str
+
+
+class DepthCheckOutput(BaseModel):
+    is_detailed_enough: bool
+    depth_score: int = Field(ge=0, le=100)
+    vague_points: List[DepthVaguePoint]
+
+
+class PlannerSectionOutput(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    id: str = ""
+    title: str
+    key_concept: str = ""
+    content_outline: List[str] = Field(default_factory=list)
+    assigned_materials: List[Dict[str, Any]] = Field(default_factory=list)
+    subsections: List[Dict[str, Any]] = Field(default_factory=list)
+
+
+class PlannerOutlineOutput(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    title: str
+    sections: List[PlannerSectionOutput]
+
+
+class KeyConceptOutput(BaseModel):
+    name: str
+    description: str
+
+
+class ReferenceOutput(BaseModel):
+    title: str
+    url: str
+    relevance: str = ""
+
+
+class ResearchSummaryOutput(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    background_knowledge: str = ""
+    key_concepts: List[KeyConceptOutput | str] = Field(default_factory=list)
+    top_references: List[ReferenceOutput] = Field(default_factory=list)
+    instructional_analysis: Optional[InstructionalAnalysis] = None
+
+
+class DistilledSourceOutput(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    title: str
+    url: str
+    core_insight: str
+    key_data: List[str]
+    unique_perspective: str
+    content_type: str
+    credibility: str
+    relevance_score: float
+
+
+class MaterialByTypeOutput(BaseModel):
+    concepts: List[str]
+    cases: List[str]
+    data: List[str]
+    comparisons: List[str]
+
+
+class SourceDistillationOutput(BaseModel):
+    sources: List[DistilledSourceOutput]
+    common_themes: List[str]
+    contradictions: List[Dict[str, str]]
+    material_by_type: MaterialByTypeOutput
+
+
+class UniqueAngleOutput(BaseModel):
+    angle: str
+    reason: str
+
+
+class WritingRecommendationsOutput(BaseModel):
+    recommended_structure: str
+    must_cover: List[str]
+    can_skip: List[str]
+    differentiation: str
+
+
+class GapAnalysisOutput(BaseModel):
+    content_gaps: List[str]
+    unique_angles: List[UniqueAngleOutput]
+    writing_recommendations: WritingRecommendationsOutput
+
+
+class DeepResearchGapOutput(BaseModel):
+    topic: str
+    reason: str
+    search_query: str
+
+
+class DeepResearchAnalysisOutput(BaseModel):
+    gaps: List[DeepResearchGapOutput]
+    coverage_score: int = Field(ge=0, le=100)
+
+
+class GoalExtractionOutput(BaseModel):
+    rational: str
+    evidence: str
+    summary: str
+
+
+class DetectedKnowledgeGapOutput(BaseModel):
+    gap: str
+    refined_query: str
+
+
+class DetectedKnowledgeGapsOutput(RootModel[List[DetectedKnowledgeGapOutput]]):
+    pass
+
+
+class CredibilityScoreOutput(BaseModel):
+    index: int = Field(ge=1)
+    authority: float = Field(ge=0, le=10)
+    freshness: float = Field(ge=0, le=10)
+    relevance: float = Field(ge=0, le=10)
+    depth: float = Field(ge=0, le=10)
+    total_score: float = Field(ge=0, le=10)
+    reason: str
+
+
+class CredibilityScoresOutput(RootModel[List[CredibilityScoreOutput]]):
+    @model_validator(mode="before")
+    @classmethod
+    def unwrap_results(cls, value):
+        if isinstance(value, dict) and "results" in value:
+            return value["results"]
+        return value
+
+
+class QueryListOutput(RootModel[List[str]]):
+    @model_validator(mode="before")
+    @classmethod
+    def unwrap_queries(cls, value):
+        if isinstance(value, dict) and "queries" in value:
+            return value["queries"]
+        return value
+
+
+class SearchRouterOutput(BaseModel):
+    sources: List[str]
+    arxiv_query: str = ""
+    blog_query: str = ""
+
+
+class KnowledgeGapsOutput(BaseModel):
+    gaps: List[KnowledgeGap]
+
+
 __all__ = [
+    "ArtistGenerationOutput",
     "AudienceAnalysis",
     "BlogOutline",
     "CodeBlock",
+    "CodeGenerationOutput",
+    "ContentEvaluationOutput",
+    "CredibilityScoresOutput",
+    "DeepResearchAnalysisOutput",
+    "DepthCheckOutput",
+    "DetectedKnowledgeGapsOutput",
+    "FactCheckOutput",
+    "GapAnalysisOutput",
+    "GoalExtractionOutput",
+    "HumanizerRewriteOutput",
+    "HumanizerScoreOutput",
     "ImageResource",
     "InformationArchitecture",
     "InstructionalAnalysis",
     "KnowledgeGap",
+    "KnowledgeGapsOutput",
     "LearningObjective",
     "QuestionResult",
+    "QueryListOutput",
+    "ResearchSummaryOutput",
     "ReviewIssue",
+    "ReviewerOutput",
     "SearchHistoryItem",
     "SearchResult",
+    "SearchRouterOutput",
     "SectionContent",
     "SectionOutline",
+    "SourceDistillationOutput",
+    "SummaryOutput",
+    "ThreadCheckOutput",
     "VaguePoint",
     "VerbatimDataItem",
+    "VoiceCheckOutput",
 ]

--- a/backend/services/blog_generator/services/deep_research_engine.py
+++ b/backend/services/blog_generator/services/deep_research_engine.py
@@ -13,10 +13,12 @@
 - DEEP_RESEARCH_MAX_ROUNDS: 最大迭代轮数（默认 3）
 - DEEP_RESEARCH_GAP_THRESHOLD: 缺口数量阈值，低于此值停止（默认 2）
 """
-import json
 import logging
 import os
 from typing import Dict, Any, List
+
+from ..schemas.outputs import DeepResearchAnalysisOutput
+from ..structured_output import parse_structured_output, repair_legacy_json
 
 logger = logging.getLogger(__name__)
 
@@ -60,12 +62,12 @@ class DeepResearchEngine:
                 messages=[{"role": "user", "content": prompt}],
                 response_format={"type": "json_object"},
             )
-            text = response.strip()
-            if '```json' in text:
-                text = text.split('```json')[1].split('```')[0].strip()
-            elif '```' in text:
-                text = text.split('```')[1].split('```')[0].strip()
-            result = json.loads(text)
+            result = parse_structured_output(
+                DeepResearchAnalysisOutput,
+                response,
+                mode="compat",
+                repair=repair_legacy_json,
+            ).model_dump(mode="json")
             return result.get('gaps', []), result.get('coverage_score', 50)
         except Exception as e:
             logger.warning(f"[DeepResearch] 缺口分析失败: {e}")

--- a/backend/services/blog_generator/services/goal_directed_extractor.py
+++ b/backend/services/blog_generator/services/goal_directed_extractor.py
@@ -8,11 +8,12 @@ Two-stage pipeline:
 Supports progressive degradation retry and fault-tolerant JSON parsing.
 Feature toggle: GOAL_EXTRACTION_ENABLED (default false).
 """
-import json
 import logging
 import os
 from dataclasses import dataclass
-from typing import Optional
+
+from ..schemas.outputs import GoalExtractionOutput
+from ..structured_output import parse_structured_output, repair_legacy_json
 
 logger = logging.getLogger(__name__)
 
@@ -97,14 +98,17 @@ class GoalDirectedExtractor:
                     kwargs["model"] = self._model_name
                 raw = self.llm_service.chat(messages, **kwargs)
 
-                result = self._parse_extraction_json(raw)
-                if result:
-                    return ExtractionResult(
-                        rational=result.get("rational", ""),
-                        evidence=result.get("evidence", ""),
-                        summary=result.get("summary", ""),
-                    )
-                logger.warning(f"Extraction empty, degrading ({i+1}/{len(retry_ratios)})")
+                result = parse_structured_output(
+                    GoalExtractionOutput,
+                    raw,
+                    mode="compat",
+                    repair=repair_legacy_json,
+                )
+                return ExtractionResult(
+                    rational=result.rational,
+                    evidence=result.evidence,
+                    summary=result.summary,
+                )
             except Exception as e:
                 logger.warning(f"LLM extraction failed: {e}, degrading")
 
@@ -123,28 +127,6 @@ class GoalDirectedExtractor:
         except ImportError:
             max_chars = max_tokens * 4
             return text[:max_chars] if len(text) > max_chars else text
-
-    @staticmethod
-    def _parse_extraction_json(raw: str) -> Optional[dict]:
-        """Fault-tolerant JSON parsing."""
-        if not raw or not raw.strip():
-            return None
-        text = raw.strip()
-        if "```json" in text:
-            text = text.split("```json")[1].split("```")[0].strip()
-        elif "```" in text:
-            text = text.split("```")[1].split("```")[0].strip()
-        try:
-            return json.loads(text)
-        except json.JSONDecodeError:
-            left = text.find("{")
-            right = text.rfind("}")
-            if left != -1 and right != -1 and left < right:
-                try:
-                    return json.loads(text[left:right + 1])
-                except json.JSONDecodeError:
-                    pass
-        return None
 
     @staticmethod
     def _truncate_chars(text: str, max_chars: int) -> str:

--- a/backend/services/blog_generator/services/knowledge_gap_detector.py
+++ b/backend/services/blog_generator/services/knowledge_gap_detector.py
@@ -7,6 +7,9 @@ import json
 import logging
 from typing import Dict, List, Optional
 
+from ..schemas.outputs import DetectedKnowledgeGapsOutput
+from ..structured_output import parse_structured_output, repair_legacy_json
+
 logger = logging.getLogger(__name__)
 
 # 按文章类型的最大搜索轮数
@@ -87,24 +90,14 @@ class KnowledgeGapDetector:
             )
             if not response:
                 return []
-            return self._parse_gaps(response)
+            return parse_structured_output(
+                DetectedKnowledgeGapsOutput,
+                response,
+                mode="compat",
+                repair=repair_legacy_json,
+            ).model_dump(mode="json")
         except Exception as e:
             logger.warning(f"知识空白检测失败: {e}")
-            return []
-
-    def _parse_gaps(self, response: str) -> List[Dict]:
-        """解析 LLM 返回的 JSON"""
-        try:
-            # 尝试提取 JSON 数组
-            text = response.strip()
-            if text.startswith("```"):
-                lines = text.split("\n")
-                text = "\n".join(lines[1:-1] if lines[-1].strip() == "```" else lines[1:])
-            gaps = json.loads(text)
-            if isinstance(gaps, list):
-                return [g for g in gaps if "gap" in g and "refined_query" in g]
-            return []
-        except (json.JSONDecodeError, TypeError):
             return []
 
     @staticmethod

--- a/backend/services/blog_generator/services/smart_search_service.py
+++ b/backend/services/blog_generator/services/smart_search_service.py
@@ -2,7 +2,6 @@
 智能知识源搜索服务 - 根据主题智能路由到不同搜索源
 """
 
-import json
 import logging
 import os
 import re
@@ -11,6 +10,8 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from .search_service import get_search_service
 from .arxiv_service import get_arxiv_service
+from ..schemas.outputs import SearchRouterOutput
+from ..structured_output import parse_structured_output, repair_legacy_json
 
 logger = logging.getLogger(__name__)
 
@@ -334,7 +335,12 @@ class SmartSearchService:
                 response_format={"type": "json_object"}
             )
 
-            result = self._extract_json(response)
+            result = parse_structured_output(
+                SearchRouterOutput,
+                response,
+                mode="compat",
+                repair=repair_legacy_json,
+            ).model_dump(mode="json")
 
             # 确保 general 始终包含
             if 'general' not in result.get('sources', []):
@@ -346,29 +352,6 @@ class SmartSearchService:
             logger.warning(f"LLM 路由失败，使用规则匹配: {e}")
             return self._rule_based_routing(topic)
 
-    @staticmethod
-    def _extract_json(text: str) -> dict:
-        """从 LLM 响应中提取 JSON（处理 markdown 包裹）"""
-        text = text.strip()
-        if '```json' in text:
-            start = text.find('```json') + 7
-            end = text.find('```', start)
-            if end != -1:
-                text = text[start:end].strip()
-            else:
-                text = text[start:].strip()
-        elif '```' in text:
-            start = text.find('```') + 3
-            end = text.find('```', start)
-            if end != -1:
-                text = text[start:end].strip()
-            else:
-                text = text[start:].strip()
-        try:
-            return json.loads(text)
-        except json.JSONDecodeError:
-            return json.loads(text, strict=False)
-    
     def _rule_based_routing(self, topic: str) -> Dict[str, Any]:
         """基于规则的简单路由（LLM 不可用时的备选）"""
         topic_lower = topic.lower()

--- a/backend/services/blog_generator/services/source_credibility_filter.py
+++ b/backend/services/blog_generator/services/source_credibility_filter.py
@@ -5,10 +5,12 @@
 四维评分，筛选高质量结果。失败时降级返回原始结果。
 """
 
-import json
 import logging
 import os
 from typing import Dict, List, Optional
+
+from ..schemas.outputs import CredibilityScoresOutput
+from ..structured_output import parse_structured_output, repair_legacy_json
 
 logger = logging.getLogger(__name__)
 
@@ -65,7 +67,12 @@ class SourceCredibilityFilter:
                 logger.warning("可信度评估返回空响应，降级返回原始列表")
                 return search_results
 
-            scores = self._parse_response(response)
+            scores = parse_structured_output(
+                CredibilityScoresOutput,
+                response,
+                mode="compat",
+                repair=repair_legacy_json,
+            ).model_dump(mode="json")
             if not scores:
                 logger.warning("可信度评估解析失败，降级返回原始列表")
                 return search_results
@@ -124,19 +131,3 @@ class SourceCredibilityFilter:
             f"total_score 加权公式：authority*0.30 + freshness*0.25 + relevance*0.30 + depth*0.15\n"
             f"仅返回 JSON 数组，不要包含 markdown 代码块或其他文本。"
         )
-
-    @staticmethod
-    def _parse_response(response: str) -> List[Dict]:
-        """解析 LLM 响应为评分列表"""
-        text = response.strip()
-        if '```json' in text:
-            text = text.split('```json')[1].split('```')[0].strip()
-        elif '```' in text:
-            text = text.split('```')[1].split('```')[0].strip()
-
-        parsed = json.loads(text)
-        if isinstance(parsed, list):
-            return parsed
-        if isinstance(parsed, dict) and 'results' in parsed:
-            return parsed['results']
-        return []

--- a/backend/services/blog_generator/services/sub_query_engine.py
+++ b/backend/services/blog_generator/services/sub_query_engine.py
@@ -6,11 +6,13 @@ LLM 生成 N 个语义互补的子查询 → ThreadPoolExecutor 并行搜索 →
 三级降级：LLM+context → LLM → 硬编码模板。
 """
 
-import json
 import logging
 import os
 from typing import Dict, Any, List, Optional
 from concurrent.futures import ThreadPoolExecutor, as_completed
+
+from ..schemas.outputs import QueryListOutput
+from ..structured_output import parse_structured_output, repair_legacy_json
 
 logger = logging.getLogger(__name__)
 
@@ -86,7 +88,13 @@ class SubQueryEngine:
             messages=[{"role": "user", "content": prompt}],
             caller="sub_query_engine",
         )
-        return self._parse_queries_response(response)
+        queries = parse_structured_output(
+            QueryListOutput,
+            response,
+            mode="compat",
+            repair=repair_legacy_json,
+        ).root
+        return [query for query in queries if query.strip()]
 
     def _build_sub_query_prompt(self, topic: str, target_audience: str, context: str) -> str:
         if self.prompt_manager and hasattr(self.prompt_manager, 'render_sub_query_generation'):
@@ -117,20 +125,6 @@ class SubQueryEngine:
             f"4. 返回 JSON 数组格式: [{examples}]\n\n"
             f"请直接返回 JSON 数组，不要包含其他内容。"
         )
-
-    @staticmethod
-    def _parse_queries_response(response: str) -> List[str]:
-        text = response.strip()
-        if '```json' in text:
-            text = text.split('```json')[1].split('```')[0].strip()
-        elif '```' in text:
-            text = text.split('```')[1].split('```')[0].strip()
-        result = json.loads(text)
-        if isinstance(result, list):
-            return [q for q in result if isinstance(q, str) and q.strip()]
-        if isinstance(result, dict) and 'queries' in result:
-            return [q for q in result['queries'] if isinstance(q, str) and q.strip()]
-        return []
 
     @staticmethod
     def _hardcoded_queries(topic: str) -> List[str]:

--- a/backend/services/blog_generator/structured_output.py
+++ b/backend/services/blog_generator/structured_output.py
@@ -32,7 +32,12 @@ _SENSITIVE_MARKER_RE = re.compile(
 _TOKEN_RE = re.compile(r"\b(?:sk|pk|AIza)-?[A-Za-z0-9_-]{8,}\b")
 _PREVIEW_LIMIT = 240
 
-__all__ = ["StructuredOutputError", "parse_structured_output"]
+__all__ = [
+    "StructuredOutputError",
+    "parse_structured_output",
+    "repair_legacy_json",
+    "repair_planner_json",
+]
 
 
 class StructuredOutputError(ValueError):
@@ -152,6 +157,131 @@ def _extract_json_text(raw: str, mode: ParseMode) -> str:
             return fenced_block.group("body").strip()
         raise _DecodeFailure([{"type": "unsupported_fenced_output"}])
     return stripped
+
+
+def repair_legacy_json(raw: str) -> str:
+    """Canonicalize legacy control characters and incomplete JSON fences once."""
+    candidate = _extract_repair_candidate(raw)
+    attempts = (
+        candidate,
+        re.sub(r'(?<!\\)\\(?!["\\/bfnrtu])', r"\\\\", candidate),
+    )
+    for attempt in attempts:
+        try:
+            payload = json.loads(attempt, strict=False)
+        except json.JSONDecodeError:
+            continue
+        return json.dumps(payload, ensure_ascii=False)
+    return raw
+
+
+def repair_planner_json(raw: str) -> str:
+    """Repair Planner-only thought prefixes and bounded truncated JSON output."""
+    candidate = _extract_repair_candidate(raw)
+    json_start = candidate.find("{")
+    if json_start < 0:
+        return raw
+    candidate = candidate[json_start:]
+
+    canonical = repair_legacy_json(candidate)
+    if canonical != candidate:
+        return canonical
+
+    initial_suffix = _json_closure_suffix(candidate)
+    if initial_suffix == "":
+        return raw
+
+    repaired = candidate.rstrip()
+    for _ in range(20):
+        completed = repaired.rstrip().rstrip(",")
+        in_string = False
+        escaped = False
+        for char in completed:
+            if escaped:
+                escaped = False
+                continue
+            if char == "\\":
+                escaped = True
+                continue
+            if char == '"':
+                in_string = not in_string
+        if in_string:
+            completed += '"'
+
+        stripped = completed.rstrip()
+        if re.search(r":\s*$", stripped):
+            completed = stripped + ' ""'
+
+        suffix = _json_closure_suffix(completed)
+        if suffix is not None:
+            completed += suffix
+
+        try:
+            json.loads(completed)
+        except json.JSONDecodeError:
+            pass
+        else:
+            return completed
+
+        cutpoints = (
+            repaired.rfind(","),
+            repaired.rfind("{"),
+            repaired.rfind("["),
+        )
+        cutpoint = max(cutpoints)
+        if cutpoint <= 0:
+            return raw
+        repaired = (
+            repaired[:cutpoint]
+            if cutpoint == cutpoints[0]
+            else repaired[: cutpoint + 1]
+        )
+    return raw
+
+
+def _json_closure_suffix(text: str) -> str | None:
+    stack = []
+    in_string = False
+    escaped = False
+    for char in text:
+        if escaped:
+            escaped = False
+            continue
+        if in_string and char == "\\":
+            escaped = True
+            continue
+        if char == '"':
+            in_string = not in_string
+            continue
+        if in_string:
+            continue
+        if char in "[{":
+            stack.append(char)
+            continue
+        if char in "]}":
+            expected = "[" if char == "]" else "{"
+            if not stack or stack[-1] != expected:
+                return None
+            stack.pop()
+    return "".join("}" if opener == "{" else "]" for opener in reversed(stack))
+
+
+def _extract_repair_candidate(raw: str) -> str:
+    stripped = raw.strip()
+    if not stripped.startswith("```"):
+        return stripped
+
+    first_newline = stripped.find("\n")
+    if first_newline < 0:
+        return stripped
+    label = stripped[3:first_newline].strip().lower()
+    if label not in {"", "json"}:
+        return stripped
+
+    candidate = stripped[first_newline + 1 :]
+    if candidate.rstrip().endswith("```"):
+        candidate = candidate.rstrip()[:-3]
+    return candidate.strip()
 
 
 def _raise_decode_error(

--- a/backend/tests/architecture/test_structured_output_boundaries.py
+++ b/backend/tests/architecture/test_structured_output_boundaries.py
@@ -1,0 +1,68 @@
+import ast
+from pathlib import Path
+
+import pytest
+
+
+BACKEND_ROOT = Path(__file__).resolve().parents[2]
+CONSUMER_MODULES = [
+    "services/blog_generator/agents/artist.py",
+    "services/blog_generator/agents/coder.py",
+    "services/blog_generator/agents/factcheck.py",
+    "services/blog_generator/agents/humanizer.py",
+    "services/blog_generator/agents/planner.py",
+    "services/blog_generator/agents/questioner.py",
+    "services/blog_generator/agents/researcher.py",
+    "services/blog_generator/agents/reviewer.py",
+    "services/blog_generator/agents/search_coordinator.py",
+    "services/blog_generator/agents/summary_generator.py",
+    "services/blog_generator/agents/thread_checker.py",
+    "services/blog_generator/agents/voice_checker.py",
+    "services/blog_generator/services/deep_research_engine.py",
+    "services/blog_generator/services/goal_directed_extractor.py",
+    "services/blog_generator/services/knowledge_gap_detector.py",
+    "services/blog_generator/services/smart_search_service.py",
+    "services/blog_generator/services/source_credibility_filter.py",
+    "services/blog_generator/services/sub_query_engine.py",
+]
+FORBIDDEN_PARSER_NAMES = {
+    "_extract_json",
+    "_parse_extraction_json",
+    "_parse_gaps",
+    "_parse_response",
+    "_parse_queries_response",
+    "_repair_truncated_json",
+}
+
+
+@pytest.mark.parametrize("relative_path", CONSUMER_MODULES)
+def test_llm_consumers_use_shared_structured_output_boundary(relative_path):
+    path = BACKEND_ROOT / relative_path
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+
+    direct_loads = [
+        node.lineno
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "json"
+        and node.func.attr == "loads"
+    ]
+    private_parsers = [
+        (node.name, node.lineno)
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name in FORBIDDEN_PARSER_NAMES
+    ]
+    shared_calls = [
+        node.lineno
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "parse_structured_output"
+    ]
+
+    assert not direct_loads, f"direct json.loads calls at lines {direct_loads}"
+    assert not private_parsers, f"private parsers remain: {private_parsers}"
+    assert shared_calls, "module does not call parse_structured_output"

--- a/backend/tests/test_69_image_critic.py
+++ b/backend/tests/test_69_image_critic.py
@@ -104,6 +104,22 @@ class TestEvaluateImage:
 
         assert result["overall_quality"] == 7.0
 
+    def test_evaluate_calculates_missing_overall_quality(self):
+        self.mock_llm.chat.return_value = json.dumps({
+            "scores": {
+                "structural_accuracy": 9,
+                "visual_clarity": 7,
+                "content_fidelity": 8,
+                "syntax_correctness": 8,
+            },
+            "specific_issues": [],
+            "improvement_suggestions": [],
+        })
+
+        result = self.agent.evaluate_image(code="flowchart TB\n    A --> B")
+
+        assert result["overall_quality"] == 8.0
+
 
 class TestImproveImage:
     def setup_method(self):

--- a/backend/tests/unit/test_consumer_output_schemas.py
+++ b/backend/tests/unit/test_consumer_output_schemas.py
@@ -1,0 +1,205 @@
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from services.blog_generator.schemas.outputs import (
+    ArtistGenerationOutput,
+    CodeGenerationOutput,
+    CredibilityScoresOutput,
+    DepthCheckOutput,
+    DetectedKnowledgeGapsOutput,
+    FactCheckOutput,
+    GoalExtractionOutput,
+    HumanizerRewriteOutput,
+    PlannerOutlineOutput,
+    QueryListOutput,
+    ResearchSummaryOutput,
+    ReviewerOutput,
+    SearchRouterOutput,
+    SourceDistillationOutput,
+    SummaryOutput,
+)
+
+
+@pytest.mark.parametrize(
+    ("model", "payload"),
+    [
+        (
+            ArtistGenerationOutput,
+            {"render_method": "mermaid", "content": "flowchart TD", "caption": "Flow"},
+        ),
+        (
+            CodeGenerationOutput,
+            {"code_block": "print(1)", "output_block": "1", "explanation": "Demo"},
+        ),
+        (
+            FactCheckOutput,
+            {"score": 5, "claims": [], "fixes": []},
+        ),
+        (
+            GoalExtractionOutput,
+            {"rational": "why", "evidence": "source", "summary": "result"},
+        ),
+        (
+            HumanizerRewriteOutput,
+            {"replacements": [{"old": "before", "new": "after"}]},
+        ),
+        (
+            SummaryOutput,
+            {
+                "tldr": "Short",
+                "seo_keywords": ["one"],
+                "social_summary": "Social",
+                "meta_description": "Meta",
+            },
+        ),
+        (
+            SearchRouterOutput,
+            {"sources": ["github"], "arxiv_query": "", "blog_query": "topic"},
+        ),
+    ],
+)
+def test_consumer_models_accept_representative_payloads(model, payload):
+    dumped = model.model_validate(payload).model_dump(mode="json")
+    assert all(dumped[key] == value for key, value in payload.items())
+
+
+@pytest.mark.parametrize(
+    ("model", "payload"),
+    [
+        (ArtistGenerationOutput, {"render_method": "mermaid", "content": "x"}),
+        (CodeGenerationOutput, {"code_block": [], "output_block": "", "explanation": ""}),
+        (GoalExtractionOutput, {"rational": "why", "evidence": "source"}),
+        (SummaryOutput, {"tldr": "Short", "seo_keywords": "one"}),
+    ],
+)
+def test_consumer_models_reject_missing_or_wrong_fields(model, payload):
+    with pytest.raises(ValidationError):
+        model.model_validate(payload)
+
+
+def test_query_list_accepts_array_and_legacy_wrapper():
+    assert QueryListOutput.model_validate(["one", "two"]).root == ["one", "two"]
+    assert QueryListOutput.model_validate({"queries": ["one", "two"]}).root == [
+        "one",
+        "two",
+    ]
+
+
+def test_credibility_scores_accept_legacy_wrapper():
+    result = CredibilityScoresOutput.model_validate(
+        {
+            "results": [
+                {
+                    "index": 1,
+                    "authority": 8,
+                    "freshness": 9,
+                    "relevance": 10,
+                    "depth": 7,
+                    "total_score": 8.6,
+                    "reason": "Official source",
+                }
+            ]
+        }
+    )
+
+    assert result.root[0].index == 1
+
+
+def test_planner_schema_requires_title_and_sections_but_preserves_extensions():
+    result = PlannerOutlineOutput.model_validate(
+        {
+            "title": "Guide",
+            "sections": [{"title": "Intro", "custom_field": "kept"}],
+            "narrative_mode": "tutorial",
+        }
+    )
+
+    dumped = result.model_dump(mode="json")
+    assert dumped["sections"][0]["custom_field"] == "kept"
+    assert dumped["narrative_mode"] == "tutorial"
+
+    with pytest.raises(ValidationError):
+        PlannerOutlineOutput.model_validate({"title": "Guide"})
+
+
+def test_reviewer_schema_rejects_invalid_nested_severity():
+    with pytest.raises(ValidationError):
+        ReviewerOutput.model_validate(
+            {
+                "score": 70,
+                "issues": [
+                    {
+                        "section_id": "one",
+                        "issue_type": "logic",
+                        "severity": "urgent",
+                        "description": "Problem",
+                        "suggestion": "Fix it",
+                    }
+                ],
+                "summary": "Needs work",
+            }
+        )
+
+
+def test_research_summary_validates_nested_instructional_analysis():
+    result = ResearchSummaryOutput.model_validate(
+        {
+            "background_knowledge": "Background",
+            "key_concepts": [{"name": "Agent", "description": "Worker"}],
+            "top_references": [{"title": "Docs", "url": "https://example.com"}],
+            "instructional_analysis": {
+                "learning_objectives": [
+                    {"type": "primary", "objective": "Understand agents"}
+                ],
+                "audience": {
+                    "knowledge_level": "beginner",
+                    "reading_purpose": "learn",
+                    "expected_outcome": "understand",
+                },
+                "content_type": "tutorial",
+                "verbatim_data": [],
+            },
+        }
+    )
+
+    dumped = result.model_dump(mode="json")
+    json.dumps(dumped)
+    assert dumped["instructional_analysis"]["content_type"] == "tutorial"
+
+
+def test_root_models_validate_nested_item_types():
+    gaps = DetectedKnowledgeGapsOutput.model_validate(
+        [{"gap": "Missing details", "refined_query": "details"}]
+    )
+    assert gaps.root[0].refined_query == "details"
+
+    depth = DepthCheckOutput.model_validate(
+        {
+            "is_detailed_enough": False,
+            "depth_score": 60,
+            "vague_points": [
+                {"location": "claim", "question": "Evidence?", "suggestion": "data"}
+            ],
+        }
+    )
+    assert depth.vague_points[0].question == "Evidence?"
+
+
+def test_source_distillation_dump_is_json_compatible():
+    result = SourceDistillationOutput.model_validate(
+        {
+            "sources": [],
+            "common_themes": [],
+            "contradictions": [],
+            "material_by_type": {
+                "concepts": [],
+                "cases": [],
+                "data": [],
+                "comparisons": [],
+            },
+        }
+    )
+
+    json.dumps(result.model_dump(mode="json"))

--- a/backend/tests/unit/test_goal_directed_extractor.py
+++ b/backend/tests/unit/test_goal_directed_extractor.py
@@ -4,7 +4,6 @@
 Tests for goal-directed web extraction:
 - ExtractionResult dataclass
 - truncate_to_tokens (tiktoken precision)
-- _parse_extraction_json (fault-tolerant JSON parsing)
 - extract() main flow
 - Progressive retry degradation
 - DeepScraper integration (feature toggle)
@@ -96,54 +95,6 @@ class TestTruncateToTokens:
 
 
 # ---------------------------------------------------------------------------
-# _parse_extraction_json
-# ---------------------------------------------------------------------------
-
-class TestParseExtractionJson:
-
-    def test_valid_json(self):
-        raw = '{"rational": "a", "evidence": "b", "summary": "c"}'
-        result = GoalDirectedExtractor._parse_extraction_json(raw)
-        assert result["rational"] == "a"
-        assert result["evidence"] == "b"
-        assert result["summary"] == "c"
-
-    def test_json_with_markdown_code_block(self):
-        raw = '```json\n{"rational": "a", "evidence": "b", "summary": "c"}\n```'
-        result = GoalDirectedExtractor._parse_extraction_json(raw)
-        assert result is not None
-        assert result["summary"] == "c"
-
-    def test_json_with_generic_code_block(self):
-        raw = '```\n{"rational": "x", "evidence": "y", "summary": "z"}\n```'
-        result = GoalDirectedExtractor._parse_extraction_json(raw)
-        assert result is not None
-        assert result["rational"] == "x"
-
-    def test_json_with_surrounding_text(self):
-        raw = 'Here is the result: {"rational": "a", "evidence": "b", "summary": "c"} done.'
-        result = GoalDirectedExtractor._parse_extraction_json(raw)
-        assert result is not None
-        assert result["evidence"] == "b"
-
-    def test_invalid_json_returns_none(self):
-        result = GoalDirectedExtractor._parse_extraction_json("not json at all")
-        assert result is None
-
-    def test_empty_string_returns_none(self):
-        result = GoalDirectedExtractor._parse_extraction_json("")
-        assert result is None
-
-    def test_none_returns_none(self):
-        result = GoalDirectedExtractor._parse_extraction_json(None)
-        assert result is None
-
-    def test_whitespace_only_returns_none(self):
-        result = GoalDirectedExtractor._parse_extraction_json("   \n  ")
-        assert result is None
-
-
-# ---------------------------------------------------------------------------
 # extract() main flow
 # ---------------------------------------------------------------------------
 
@@ -155,6 +106,21 @@ class TestExtract:
         assert result.rational != ""
         assert result.evidence != ""
         assert result.summary != ""
+
+    @pytest.mark.parametrize("language", ["json", ""])
+    def test_accepts_fenced_structured_result(self, mock_llm, sample_content, language):
+        mock_llm.chat.return_value = (
+            f"```{language}\n"
+            '{"rational":"a","evidence":"b","summary":"c"}'
+            "\n```"
+        )
+
+        result = GoalDirectedExtractor(llm_service=mock_llm).extract(
+            sample_content, "RAG"
+        )
+
+        assert result.success is True
+        assert result.summary == "c"
 
     def test_empty_content_returns_failure(self, extractor):
         result = extractor.extract("", "any goal")
@@ -280,4 +246,3 @@ class TestDeepScraperIntegration:
             call_args = mock_llm.chat.call_args
             prompt_content = call_args[0][0][0]["content"]
             assert "specific RAG goal" in prompt_content
-

--- a/backend/tests/unit/test_research_service_structured_output.py
+++ b/backend/tests/unit/test_research_service_structured_output.py
@@ -1,0 +1,182 @@
+import json
+from unittest.mock import MagicMock
+
+from services.blog_generator.services.deep_research_engine import DeepResearchEngine
+from services.blog_generator.services.goal_directed_extractor import GoalDirectedExtractor
+from services.blog_generator.services.knowledge_gap_detector import KnowledgeGapDetector
+from services.blog_generator.services.smart_search_service import SmartSearchService
+from services.blog_generator.services.source_credibility_filter import SourceCredibilityFilter
+from services.blog_generator.services.sub_query_engine import SubQueryEngine
+from services.blog_generator.agents.researcher import ResearcherAgent
+
+
+def test_deep_research_validation_failure_preserves_gap_fallback():
+    llm = MagicMock()
+    llm.chat.return_value = json.dumps(
+        {"gaps": [{"topic": "Missing", "reason": "Why"}], "coverage_score": 30}
+    )
+
+    result = DeepResearchEngine(llm, search_service=None)._analyze_gaps(
+        "Topic", "Knowledge", []
+    )
+
+    assert result == ([], 80)
+
+
+def test_goal_extractor_validation_failure_retries_then_fails():
+    llm = MagicMock()
+    llm.chat.return_value = json.dumps({"rational": "Why", "evidence": "Proof"})
+
+    result = GoalDirectedExtractor(llm_service=llm).extract("Content", "Goal")
+
+    assert result.success is False
+    assert llm.chat.call_count == 4
+
+
+def test_knowledge_gap_validation_failure_preserves_empty_fallback():
+    llm = MagicMock()
+    llm.chat.return_value = json.dumps(
+        [{"gap": "Missing detail", "refined_query": ["invalid"]}]
+    )
+
+    result = KnowledgeGapDetector(llm_service=llm).detect([], "Topic")
+
+    assert result == []
+
+
+def test_smart_search_validation_failure_preserves_rule_based_fallback():
+    service = SmartSearchService.__new__(SmartSearchService)
+    service.llm = MagicMock()
+    service.llm.chat.return_value = json.dumps(
+        {"sources": ["general"], "arxiv_query": [], "blog_query": "Topic"}
+    )
+
+    result = service._route_search_sources("Topic")
+
+    assert result == {
+        "sources": ["general"],
+        "arxiv_query": "Topic",
+        "blog_query": "Topic",
+    }
+
+
+def test_sub_query_validation_failure_preserves_three_level_fallback():
+    llm = MagicMock()
+    llm.chat.return_value = json.dumps(["first", "second", 7])
+    engine = SubQueryEngine(llm_client=llm, search_service=None)
+
+    result = engine.generate_sub_queries("Topic")
+
+    assert result == engine._hardcoded_queries("Topic")
+    assert llm.chat.call_count == 2
+
+
+def test_research_summary_preserves_legacy_alternative_concept_key(monkeypatch):
+    monkeypatch.setenv("RESEARCHER_CACHE_ENABLED", "false")
+    llm = MagicMock()
+    llm.chat.return_value = json.dumps(
+        {"keyConcepts": [{"name": "Agent", "description": "Worker"}]}
+    )
+
+    result = ResearcherAgent(llm).summarize(
+        "Topic",
+        [{"title": "Source", "url": "https://example.com", "content": "Text"}],
+        "beginner",
+    )
+
+    assert result == {
+        "background_knowledge": "",
+        "key_concepts": [{"name": "Agent", "description": "Worker"}],
+        "top_references": [],
+        "instructional_analysis": None,
+    }
+
+
+def test_researcher_run_normalizes_missing_instructional_analysis(monkeypatch):
+    monkeypatch.setenv("RESEARCHER_CACHE_ENABLED", "false")
+    monkeypatch.setenv("SMART_SEARCH_ENABLED", "false")
+    researcher = ResearcherAgent(llm_client=None)
+    researcher.search = MagicMock(
+        return_value=[
+            {"title": "Source", "url": "https://example.com", "content": "Text"}
+        ]
+    )
+    researcher.summarize = MagicMock(
+        return_value={
+            "background_knowledge": "Background",
+            "key_concepts": [],
+            "top_references": [],
+            "instructional_analysis": None,
+        }
+    )
+    researcher.distill = MagicMock(return_value={})
+    researcher.analyze_gaps = MagicMock(return_value={})
+
+    result = researcher.run({"topic": "Topic", "target_audience": "beginner"})
+
+    assert result["instructional_analysis"] == {}
+    assert result["learning_objectives"] == []
+    assert result["verbatim_data"] == []
+
+
+def _credibility_results():
+    return [
+        {"title": f"Source {index}", "url": f"https://example.com/{index}"}
+        for index in range(1, 7)
+    ]
+
+
+def test_source_credibility_filter_maps_and_sorts_valid_scores():
+    llm = MagicMock()
+    llm.chat.return_value = json.dumps(
+        {
+            "results": [
+                {
+                    "index": 2,
+                    "authority": 9,
+                    "freshness": 8,
+                    "relevance": 9,
+                    "depth": 8,
+                    "total_score": 8.7,
+                    "reason": "Strong",
+                },
+                {
+                    "index": 1,
+                    "authority": 7,
+                    "freshness": 7,
+                    "relevance": 7,
+                    "depth": 7,
+                    "total_score": 7.0,
+                    "reason": "Useful",
+                },
+            ]
+        }
+    )
+
+    result = SourceCredibilityFilter(llm).curate("Topic", _credibility_results())
+
+    assert [item["title"] for item in result] == ["Source 2", "Source 1"]
+    assert result[0]["credibility_score"] == 8.7
+    assert result[0]["credibility_detail"]["reason"] == "Strong"
+
+
+def test_source_credibility_filter_validation_failure_returns_original_results():
+    llm = MagicMock()
+    llm.chat.return_value = json.dumps(
+        [
+            {
+                "index": 1,
+                "authority": "invalid",
+                "freshness": 8,
+                "relevance": 9,
+                "depth": 8,
+                "total_score": 8.7,
+                "reason": "Bad score",
+            }
+        ]
+    )
+    original = _credibility_results()
+
+    result = SourceCredibilityFilter(llm).curate("Topic", original)
+
+    assert result is original

--- a/backend/tests/unit/test_structured_output_consumers.py
+++ b/backend/tests/unit/test_structured_output_consumers.py
@@ -1,0 +1,274 @@
+import json
+
+import pytest
+
+from services.blog_generator.agents.artist import ArtistAgent
+from services.blog_generator.agents.coder import CoderAgent
+from services.blog_generator.agents.factcheck import FactCheckAgent
+from services.blog_generator.agents.humanizer import HumanizerAgent
+from services.blog_generator.agents.planner import PlannerAgent
+from services.blog_generator.agents.questioner import QuestionerAgent
+from services.blog_generator.agents.researcher import ResearcherAgent
+from services.blog_generator.agents.reviewer import ReviewerAgent
+from services.blog_generator.agents.search_coordinator import SearchCoordinator
+from services.blog_generator.agents.summary_generator import SummaryGeneratorAgent
+from services.blog_generator.agents.thread_checker import ThreadCheckerAgent
+from services.blog_generator.agents.voice_checker import VoiceCheckerAgent
+from services.blog_generator.structured_output import StructuredOutputError
+
+
+class StaticLLM:
+    def __init__(self, payload):
+        self.payload = payload
+        self.calls = 0
+
+    def chat(self, *args, **kwargs):
+        self.calls += 1
+        return self.payload
+
+
+def test_artist_rejects_missing_required_caption():
+    llm = StaticLLM(
+        json.dumps({"render_method": "ai_image", "content": "image prompt"})
+    )
+
+    with pytest.raises(StructuredOutputError) as raised:
+        ArtistAgent(llm).generate_image("comparison", "Compare", "Context")
+
+    assert raised.value.kind == "validation"
+
+
+def test_factcheck_validation_failure_uses_existing_error_report_fallback():
+    llm = StaticLLM(json.dumps({"score": "invalid", "claims": [], "fixes": []}))
+    state = {
+        "sections": [{"id": "s1", "title": "One", "content": "Claim"}],
+        "search_results": [],
+    }
+
+    result = FactCheckAgent(llm).run(state)
+
+    assert "error" in result["factcheck_report"]
+
+
+def test_humanizer_rejects_invalid_nested_score_type():
+    llm = StaticLLM(
+        json.dumps(
+            {
+                "score": {
+                    "directness": 8,
+                    "rhythm": 8,
+                    "trust": 8,
+                    "authenticity": 8,
+                    "conciseness": 8,
+                    "total": [],
+                },
+                "issues_summary": "none",
+            }
+        )
+    )
+
+    with pytest.raises(StructuredOutputError) as raised:
+        HumanizerAgent(llm)._score_section("Natural text")
+
+    assert raised.value.kind == "validation"
+
+
+def test_reviewer_validation_failure_preserves_default_approval_fallback():
+    llm = StaticLLM(
+        json.dumps(
+            {
+                "score": 70,
+                "approved": False,
+                "issues": [
+                    {
+                        "section_id": "s1",
+                        "issue_type": "logic",
+                        "severity": "urgent",
+                        "description": "Problem",
+                        "suggestion": "Fix",
+                    }
+                ],
+                "summary": "Needs work",
+            }
+        )
+    )
+
+    result = ReviewerAgent(llm).review("Document", {})
+
+    assert result == {
+        "score": 80,
+        "approved": True,
+        "issues": [],
+        "summary": "审核完成",
+    }
+
+
+def test_summary_validation_failure_leaves_existing_state_unchanged():
+    llm = StaticLLM(
+        json.dumps(
+            {
+                "tldr": "Short",
+                "seo_keywords": "not-a-list",
+                "social_summary": "Social",
+                "meta_description": "Meta",
+            }
+        )
+    )
+    state = {"final_markdown": "# Article", "outline": {"title": "Article"}}
+
+    result = SummaryGeneratorAgent(llm).run(state)
+
+    assert result["final_markdown"] == "# Article"
+    assert "seo_keywords" not in result
+
+
+def test_thread_checker_validation_failure_preserves_empty_issue_fallback():
+    llm = StaticLLM(
+        json.dumps(
+            {
+                "overall_coherence": 2,
+                "issues": [
+                    {
+                        "check_type": "transition",
+                        "severity": "urgent",
+                        "section_id": "s1",
+                        "description": "Problem",
+                        "suggestion": "Fix",
+                    }
+                ],
+                "summary": "Needs work",
+            }
+        )
+    )
+    state = {
+        "sections": [
+            {"id": "s1", "title": "One", "content": "First"},
+            {"id": "s2", "title": "Two", "content": "Second"},
+        ],
+        "outline": {},
+    }
+
+    result = ThreadCheckerAgent(llm).run(state)
+
+    assert result["thread_issues"] == []
+
+
+def test_voice_checker_validation_failure_preserves_empty_issue_fallback():
+    llm = StaticLLM(
+        json.dumps(
+            {
+                "voice_profile": {
+                    "target_tone": "clear",
+                    "target_formality": "medium",
+                    "target_person": "second",
+                },
+                "chapter_voice_map": [],
+                "issues": [
+                    {
+                        "check_type": "tone_consistency",
+                        "severity": "urgent",
+                        "section_id": "s1",
+                        "description": "Problem",
+                        "suggestion": "Fix",
+                    }
+                ],
+                "summary": "Needs work",
+            }
+        )
+    )
+    state = {
+        "sections": [
+            {"id": "s1", "title": "One", "content": "First"},
+            {"id": "s2", "title": "Two", "content": "Second"},
+        ]
+    }
+
+    result = VoiceCheckerAgent(llm).run(state)
+
+    assert result["voice_issues"] == []
+
+
+def test_coder_rejects_non_string_code_block():
+    llm = StaticLLM(
+        json.dumps(
+            {"code_block": [], "output_block": "", "explanation": "Example"}
+        )
+    )
+
+    with pytest.raises(StructuredOutputError) as raised:
+        CoderAgent(llm).generate_code("Example", "Context")
+
+    assert raised.value.kind == "validation"
+
+
+def test_questioner_validation_failure_preserves_depth_fallback():
+    llm = StaticLLM(
+        json.dumps(
+            {
+                "is_detailed_enough": False,
+                "depth_score": 20,
+                "vague_points": [
+                    {"location": "intro", "suggestion": "Add an example"}
+                ],
+            }
+        )
+    )
+
+    result = QuestionerAgent(llm).check_depth("Content", {})
+
+    assert result == {
+        "is_detailed_enough": True,
+        "depth_score": 80,
+        "vague_points": [],
+    }
+
+
+def test_search_coordinator_validation_failure_preserves_empty_gap_fallback():
+    llm = StaticLLM(
+        json.dumps(
+            {
+                "gaps": [
+                    {
+                        "gap_type": "unknown",
+                        "description": "Missing detail",
+                        "suggested_query": "topic detail",
+                    }
+                ]
+            }
+        )
+    )
+
+    result = SearchCoordinator(llm, search_service=None).detect_knowledge_gaps(
+        "Content", "Knowledge"
+    )
+
+    assert result == []
+
+
+def test_researcher_validation_failure_preserves_default_queries(monkeypatch):
+    monkeypatch.setenv("RESEARCHER_CACHE_ENABLED", "false")
+    llm = StaticLLM(json.dumps(["topic overview", 7]))
+
+    result = ResearcherAgent(llm).generate_search_queries("topic", "beginner")
+
+    assert result == [
+        "topic 教程 tutorial",
+        "topic 最佳实践 best practices",
+        "topic 常见问题 FAQ",
+    ]
+
+
+def test_planner_uses_explicit_repair_for_nested_truncated_output():
+    llm = StaticLLM(
+        'thinking first\n{"title":"T","sections":[{"title":"One",'
+        '"subsections":[{"title":"Nested"'
+    )
+
+    result = PlannerAgent(llm).generate_outline(
+        topic="Topic",
+        article_type="tutorial",
+        target_audience="beginner",
+    )
+
+    assert result["title"] == "T"
+    assert result["sections"][0]["subsections"] == [{"title": "Nested"}]

--- a/backend/tests/unit/test_structured_output_repairs.py
+++ b/backend/tests/unit/test_structured_output_repairs.py
@@ -1,0 +1,96 @@
+import pytest
+
+from services.blog_generator.schemas.outputs import (
+    HumanizerRewriteOutput,
+    PlannerOutlineOutput,
+)
+from services.blog_generator.structured_output import (
+    StructuredOutputError,
+    parse_structured_output,
+    repair_legacy_json,
+    repair_planner_json,
+)
+
+
+def test_legacy_repair_accepts_incomplete_json_fence():
+    raw = '```json\n{"replacements": []}'
+
+    result = parse_structured_output(
+        HumanizerRewriteOutput,
+        raw,
+        mode="compat",
+        repair=repair_legacy_json,
+    )
+
+    assert result.replacements == []
+
+
+def test_legacy_repair_normalizes_control_characters():
+    raw = '{"replacements":[{"old":"line\nbreak","new":"fixed"}]}'
+
+    result = parse_structured_output(
+        HumanizerRewriteOutput,
+        raw,
+        mode="compat",
+        repair=repair_legacy_json,
+    )
+
+    assert result.replacements[0].old == "line\nbreak"
+
+
+def test_legacy_repair_normalizes_invalid_backslashes():
+    raw = r'{"replacements":[{"old":"C:\temp\q","new":"fixed"}]}'
+
+    result = parse_structured_output(
+        HumanizerRewriteOutput,
+        raw,
+        mode="compat",
+        repair=repair_legacy_json,
+    )
+
+    assert result.replacements[0].old == "C:\temp\\q"
+
+
+def test_legacy_repair_does_not_extract_outer_braces_from_prose():
+    raw = 'analysis before {"replacements": []} analysis after'
+
+    with pytest.raises(StructuredOutputError) as raised:
+        parse_structured_output(
+            HumanizerRewriteOutput,
+            raw,
+            mode="compat",
+            repair=repair_legacy_json,
+        )
+
+    assert raised.value.kind == "decode"
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        'thinking first\n{"title":"T","sections":[{"title":"One"',
+        '```json\n{"title":"T","sections":[{"title":"One"',
+    ],
+)
+def test_planner_repair_handles_golden_truncation_cases(raw):
+    result = parse_structured_output(
+        PlannerOutlineOutput,
+        raw,
+        mode="compat",
+        repair=repair_planner_json,
+    )
+
+    assert result.title == "T"
+    assert [section.title for section in result.sections] == ["One"]
+
+
+def test_planner_repair_rejects_content_without_json_object():
+    with pytest.raises(StructuredOutputError) as raised:
+        parse_structured_output(
+            PlannerOutlineOutput,
+            "thinking without structured output",
+            mode="compat",
+            repair=repair_planner_json,
+        )
+
+    assert raised.value.kind == "decode"


### PR DESCRIPTION
## Summary
- migrate 12 blog-generation agents and 6 research services to the shared Pydantic structured-output boundary
- centralize legacy JSON compatibility repair and keep truncation repair explicit and Planner-only
- remove private JSON parsers and add an AST boundary guard for all 18 consumers
- preserve retry and fallback behavior, including Researcher legacy concept keys and optional scoring fields

## Test plan
- [x] python -m pytest tests/ -q
- [x] python -m compileall -q services/blog_generator
- [x] git diff --check

Full backend result: 1380 passed, 12 skipped, 15 warnings.

Part of #159 (PR2). Depends on the structured-output contract merged in #167.