### PR TITLE
refactor: extract generation orchestration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the Vibe Blog project will be documented in this file.
 
 ---
 
+## 2026-08-01
+
+### Changed
+- ♻️ **生成编排职责拆分** — 将任务事件桥接、结果持久化收尾、LangGraph 图构建与执行入口拆分为独立组件，同时保留现有服务门面、节点拓扑和 SSE 行为。
+
+### Tests
+- ✨ **生成编排回归契约** — 覆盖公开签名、图拓扑、执行委托、结果收尾顺序、事件处理器清理及模块依赖边界。
+
 ## 2026-07-31
 
 ### Changed

--- a/backend/services/blog_generator/blog_service.py
+++ b/backend/services/blog_generator/blog_service.py
@@ -16,6 +16,11 @@ from infrastructure.paths import RuntimePaths
 
 from .queue_bridge import update_queue_status, update_queue_progress
 from .generator import BlogGenerator
+from .lifecycle.result_pipeline import (
+    GenerationResultPipeline,
+    GenerationResultRequest,
+)
+from .lifecycle.task_events import TaskEventBridge
 from .schemas.state import create_initial_state
 from .services.search_service import SearchService, init_search_service, get_search_service
 from .post_processors.markdown_formatter import MarkdownFormatter
@@ -66,6 +71,7 @@ class BlogService:
             knowledge_service=knowledge_service
         )
         self.generator.compile()
+        self._result_pipeline = GenerationResultPipeline(self)
 
         # 101.113: 记录正在等待大纲确认的任务（用于 resume 时查找 config）
         self._interrupted_tasks: Dict[str, Dict] = {}  # task_id -> {config, task_manager, ...}
@@ -565,131 +571,13 @@ class BlogService:
         执行生成流程，发送 SSE 事件
         """
         import time
-        import logging
-        
-        # 创建一个自定义日志处理器，将日志推送到前端
-        class SSELogHandler(logging.Handler):
-            def __init__(self, task_manager, task_id):
-                super().__init__()
-                self.task_manager = task_manager
-                self.task_id = task_id
-                
-            def emit(self, record):
-                if self.task_manager and record.name.startswith('services.blog_generator'):
-                    # 队列已销毁则自动移除自身，防止 handler 泄漏
-                    if not self.task_manager.get_queue(self.task_id):
-                        logging.getLogger(record.name).removeHandler(self)
-                        return
-                    msg = self.format(record)
-                    self.task_manager.send_event(self.task_id, 'log', {
-                        'level': record.levelname,
-                        'logger': record.name.split('.')[-1],
-                        'message': msg
-                    })
-                    # 识别搜索日志，额外推送结构化 result 事件
-                    self._emit_structured_search_event(msg, record)
+        event_bridge = TaskEventBridge(self.generator, task_manager, task_id)
+        sse_handler = event_bridge.attach()
+        sse_logger_names = event_bridge.logger_names
 
-            def _emit_structured_search_event(self, msg, record):
-                """从日志中识别搜索/爬取模式，推送结构化 result 事件"""
-                import re
-                import json as _json
-                try:
-                    # 搜索开始: "使用智谱 Web Search 搜索: xxx" 或 "启动智能知识源搜索"
-                    m = re.search(r'(?:Web Search 搜索|智能.*搜索)[：:]\s*(.+)', msg)
-                    if m:
-                        self.task_manager.send_event(self.task_id, 'result', {
-                            'type': 'search_started',
-                            'data': {'query': m.group(1).strip()}
-                        })
-                        return
-                    # 搜索请求参数: 包含 search_query 的 JSON
-                    if '请求参数' in msg and 'search_query' in msg:
-                        m2 = re.search(r'\{.*\}', msg)
-                        if m2:
-                            try:
-                                payload = _json.loads(m2.group(0))
-                                self.task_manager.send_event(self.task_id, 'result', {
-                                    'type': 'search_started',
-                                    'data': {'query': payload.get('search_query', '')}
-                                })
-                            except _json.JSONDecodeError:
-                                pass
-                        return
-                    # 深度抓取完成: "深度抓取完成: N 篇高质量素材"
-                    m3 = re.search(r'深度抓取完成[：:]\s*(\d+)', msg)
-                    if m3:
-                        self.task_manager.send_event(self.task_id, 'result', {
-                            'type': 'crawl_completed',
-                            'data': {'count': int(m3.group(1))}
-                        })
-                        return
-                    # 智能搜索完成: "智能搜索完成，使用搜索源: [...]"
-                    if '智能搜索完成' in msg:
-                        self.task_manager.send_event(self.task_id, 'result', {
-                            'type': 'search_completed',
-                            'data': {'message': msg}
-                        })
-                        return
-                except Exception:
-                    pass
-        
-        # 添加日志处理器
-        sse_handler = None
-        sse_logger_names = [
-            "services.blog_generator.generator",
-            "services.blog_generator.agents.researcher",
-            "services.blog_generator.agents.planner",
-            "services.blog_generator.agents.writer",
-            "services.blog_generator.agents.questioner",
-            "services.blog_generator.agents.coder",
-            "services.blog_generator.agents.artist",
-            "services.blog_generator.agents.reviewer",
-            "services.blog_generator.agents.assembler",
-            "services.blog_generator.agents.search_coordinator",
-            "services.blog_generator.services.search_service",
-            "services.media.image_service",
-        ]
-        if task_manager:
-            sse_handler = SSELogHandler(task_manager, task_id)
-            sse_handler.setLevel(logging.INFO)
-            sse_handler.setFormatter(logging.Formatter('%(message)s'))
-            
-            # 给所有 blog_generator 相关的 logger 添加处理器
-            for logger_name in sse_logger_names:
-                logging.getLogger(logger_name).addHandler(sse_handler)
-        
         # 等待 SSE 连接建立
         time.sleep(0.5)
-
-        # 注入 SSE 事件推送到 LLMService（37.34）
-        if task_manager:
-            try:
-                llm = self.generator.llm
-                llm.task_manager = task_manager
-                llm.task_id = task_id
-                # v2 方案 10: LLM 调用完整日志
-                from utils.llm_logger import LLMCallLogger
-                llm.llm_logger = LLMCallLogger(task_id)
-            except Exception:
-                pass
-
-        # 注入 task_manager 到 researcher、search_service、writer（101.03 SSE 事件推送）
-        if task_manager:
-            try:
-                researcher = self.generator.researcher
-                researcher.task_manager = task_manager
-                researcher.task_id = task_id
-                if researcher.search_service:
-                    researcher.search_service.task_manager = task_manager
-                    researcher.search_service.task_id = task_id
-            except Exception:
-                pass
-            try:
-                writer = self.generator.writer
-                writer.task_manager = task_manager
-                writer.task_id = task_id
-            except Exception:
-                pass
+        event_bridge.inject_dependencies()
 
         # 创建 Token 追踪器（37.31）
         token_tracker = None
@@ -1174,6 +1062,7 @@ class BlogService:
                     'article_config': article_config,
                     'token_tracker': token_tracker,
                     'task_log': task_log,
+                    'event_bridge': event_bridge,
                     'sse_handler': sse_handler,
                     'sse_logger_names': sse_logger_names,
                 }
@@ -1181,204 +1070,28 @@ class BlogService:
                 _interrupted = True
                 return
 
-            # 获取最终状态
             final_state = snapshot.values
-            markdown_content = self._validate_final_state(final_state)
-            
-            # 生成封面架构图（基于全文内容）
-            outline = final_state.get('outline') or {}
-            # 从 final_state 获取图片风格参数
-            image_style = final_state.get('image_style', '')
-            cover_image_result = None
-            if generate_images:
-                cover_image_result = self._generate_cover_image(
-                    title=outline.get('title', topic),
-                    topic=topic,
-                    full_content=markdown_content,
-                    task_manager=task_manager,
+            result_pipeline = getattr(self, "_result_pipeline", None)
+            if result_pipeline is None:
+                result_pipeline = GenerationResultPipeline(self)
+            result = result_pipeline.finalize(
+                GenerationResultRequest(
                     task_id=task_id,
-                    image_style=image_style,
-                    video_aspect_ratio=video_aspect_ratio if generate_cover_video else "16:9"
-                )
-            else:
-                logger.info("图片生成已禁用，跳过封面图")
-            # 解构返回值：(外网URL, 本地路径, 文章摘要)
-            cover_image_url = cover_image_result[0] if cover_image_result else None
-            cover_image_path = cover_image_result[1] if cover_image_result else None
-            article_summary = cover_image_result[2] if cover_image_result and len(cover_image_result) > 2 else None
-            
-            # 自动保存 Markdown 到文件（包含封面图）
-            saved_path = None
-            
-            # 如果有封面图，在 Markdown 中插入封面图
-            markdown_with_cover = markdown_content
-            if cover_image_path and markdown_content:
-                title = outline.get('title', topic)
-                # 判断是 OSS URL 还是本地路径
-                if cover_image_path.startswith('http'):
-                    # OSS URL，直接使用
-                    cover_image_ref = cover_image_path
-                else:
-                    # 本地路径，使用相对路径
-                    cover_filename = os.path.basename(cover_image_path)
-                    cover_image_ref = f"./images/{cover_filename}"
-                cover_section = f"\n![{title} - 架构图]({cover_image_ref})\n\n---\n\n"
-                # 在第一个 ## 之前插入封面图
-                lines = markdown_content.split('\n')
-                insert_idx = 0
-                for i, line in enumerate(lines):
-                    if line.startswith('## ') and i > 0:
-                        insert_idx = i
-                        break
-                if insert_idx > 0:
-                    lines.insert(insert_idx, cover_section)
-                    markdown_with_cover = '\n'.join(lines)
-                else:
-                    markdown_with_cover = cover_section + markdown_content
-            
-            if markdown_content:
-                saved_path = self._save_markdown(
-                    task_id=task_id,
-                    markdown=markdown_content,
-                    outline=outline,
-                    cover_image_path=cover_image_path
-                )
-            
-            # 生成封面动画（如果用户选择了该选项且功能已启用）
-            cover_video_path = None
-            cover_video_enabled = os.environ.get('COVER_VIDEO_ENABLED', 'true').lower() == 'true'
-            if generate_cover_video and cover_image_url and cover_video_enabled:
-                # 获取章节配图（用于多图序列模式）
-                section_images = final_state.get('section_images', [])
-                cover_video_path = self._generate_cover_video(
-                    history_id=task_id,
-                    cover_image_url=cover_image_url,
-                    video_aspect_ratio=video_aspect_ratio,
-                    task_manager=task_manager,
-                    task_id=task_id,
-                    section_images=section_images
-                )
-            
-            # 构建 citations 列表（合并 search_results + top_references，URL 去重）
-            citations = []
-            seen_urls = set()
-            for src_list_key in ('search_results', 'top_references'):
-                for r in (final_state.get(src_list_key) or []):
-                    url = r.get('url') or r.get('source', '')
-                    if not url or url in seen_urls:
-                        continue
-                    seen_urls.add(url)
-                    try:
-                        from urllib.parse import urlparse
-                        domain = urlparse(url).hostname or ''
-                    except Exception:
-                        domain = ''
-                    citations.append({
-                        'url': url,
-                        'title': r.get('title', ''),
-                        'domain': domain,
-                        'snippet': (r.get('content', '') or r.get('snippet', ''))[:80],
-                    })
-
-            # 保存历史记录（使用包含封面图的 markdown）
-            try:
-                from services.database_service import get_db_service
-                import json
-                db_service = get_db_service()
-                db_service.save_history(
-                    history_id=task_id,
                     topic=topic,
                     article_type=article_type,
                     target_length=target_length,
-                    markdown_content=markdown_with_cover,
-                    outline=json.dumps(final_state.get('outline') or {}, ensure_ascii=False),
-                    sections_count=len(final_state.get('sections', [])),
-                    code_blocks_count=len(final_state.get('code_blocks', [])),
-                    images_count=len(final_state.get('images', [])),
-                    review_score=final_state.get('review_score', 0),
-                    cover_image=cover_image_path,
-                    cover_video=cover_video_path,
-                    target_sections_count=article_config.get('sections_count'),
-                    target_images_count=article_config.get('images_count'),
-                    target_code_blocks_count=article_config.get('code_blocks_count'),
-                    target_word_count=article_config.get('target_word_count'),
-                    citations=json.dumps(citations, ensure_ascii=False) if citations else None
-                )
-                logger.info(f"历史记录已保存: {task_id}")
-
-                self._send_completion_event(
-                    task_manager=task_manager,
-                    task_id=task_id,
                     final_state=final_state,
-                    markdown=markdown_with_cover,
-                    saved_path=saved_path,
-                    cover_video_path=cover_video_path,
-                    citations=citations,
+                    article_config=article_config,
+                    generate_images=generate_images,
+                    generate_cover_video=generate_cover_video,
+                    video_aspect_ratio=video_aspect_ratio,
+                    task_manager=task_manager,
+                    token_tracker=token_tracker,
+                    task_log=task_log,
+                    record_memory=True,
                 )
-
-                # 102.03: 记录用户行为到记忆存储
-                if self.generator._memory_storage:
-                    try:
-                        user_id = 'default'
-                        self.generator._memory_storage.add_fact(
-                            user_id,
-                            f"生成了关于 {topic} 的 {article_type} 文章",
-                            category="behavior",
-                            confidence=0.8,
-                            source=f"task:{task_id}",
-                        )
-                    except Exception as e:
-                        logger.debug(f"记忆记录跳过: {e}")
-
-                # 保存博客摘要（复用封面图生成时的摘要，避免重复调用 LLM）
-                try:
-                    summary_to_save = article_summary
-                    # 如果没有摘要（封面图生成失败或跳过），则单独生成
-                    if not summary_to_save:
-                        summary_to_save = extract_article_summary(
-                            llm_client=self.generator.llm,
-                            title=topic,
-                            content=markdown_with_cover,
-                            max_length=500
-                        )
-                    
-                    if summary_to_save:
-                        # 截取前 500 字作为摘要
-                        summary_to_save = summary_to_save[:500]
-                        db_service.update_history_summary(task_id, summary_to_save)
-                        logger.info(f"博客摘要已保存: {task_id}")
-                except Exception as e:
-                    logger.warning(f"保存博客摘要失败: {e}")
-                    
-            except Exception as e:
-                logger.warning(f"保存历史记录失败: {e}")
-                raise RuntimeError(f"保存历史记录失败: {e}") from e
-            
-            # 完成 Token 追踪（37.31）
-            token_summary = None
-            if token_tracker:
-                try:
-                    logger.info(token_tracker.format_summary())
-                    token_summary = token_tracker.get_summary()
-                except Exception as e:
-                    logger.warning(f"Token 摘要生成失败: {e}")
-
-            # 完成结构化任务日志（37.08）
-            if task_log:
-                try:
-                    task_log.complete(
-                        score=final_state.get('review_score', 0),
-                        word_count=len(final_state.get('final_markdown', '')),
-                        revision_rounds=final_state.get('revision_count', 0),
-                    )
-                    if token_summary:
-                        task_log.token_summary = token_summary
-                    task_log.save()
-                    logger.info(task_log.get_summary())
-                except Exception as e:
-                    logger.warning(f"任务日志保存失败: {e}")
-
-            logger.info(f"博客生成完成: {task_id}, 保存到: {saved_path}")
+            )
+            logger.info(f"博客生成完成: {task_id}, 保存到: {result.saved_path}")
 
         except Exception as e:
             logger.error(f"博客生成失败 [{task_id}]: {e}", exc_info=True)
@@ -1396,9 +1109,8 @@ class BlogService:
             update_queue_status(task_id, "failed", error_msg=str(e))
         finally:
             # 清理日志处理器（interrupt 暂停时不清理，留给 _run_resume）
-            if sse_handler and not locals().get('_interrupted'):
-                for logger_name in sse_logger_names:
-                    logging.getLogger(logger_name).removeHandler(sse_handler)
+            if not locals().get('_interrupted'):
+                event_bridge.close()
             # 清理按任务分离的文本日志 handler
             if task_log_handler and not locals().get('_interrupted'):
                 from logging_config import remove_task_logger
@@ -1440,6 +1152,7 @@ class BlogService:
         article_config = task_info.get('article_config', {})
         token_tracker = task_info.get('token_tracker')
         task_log = task_info.get('task_log')
+        event_bridge = task_info.get('event_bridge')
         sse_handler = task_info.get('sse_handler')
         sse_logger_names = task_info.get('sse_logger_names', [])
 
@@ -1630,197 +1343,29 @@ class BlogService:
                                 }
                             })
 
-            # 获取最终状态
             final_state = self.generator.app.get_state(config).values
-            markdown_content = self._validate_final_state(final_state)
-
-            # 封面图 + 保存历史 + 完成事件（复用 _run_generation 逻辑）
-            outline = final_state.get('outline') or {}
-            image_style = final_state.get('image_style', '')
-            cover_image_result = None
-            if generate_images:
-                cover_image_result = self._generate_cover_image(
-                    title=outline.get('title', topic),
-                    topic=topic,
-                    full_content=markdown_content,
-                    task_manager=task_manager,
+            result_pipeline = getattr(self, "_result_pipeline", None)
+            if result_pipeline is None:
+                result_pipeline = GenerationResultPipeline(self)
+            result = result_pipeline.finalize(
+                GenerationResultRequest(
                     task_id=task_id,
-                    image_style=image_style,
-                    video_aspect_ratio=video_aspect_ratio if generate_cover_video else "16:9"
-                )
-            else:
-                logger.info("图片生成已禁用，跳过封面图")
-            cover_image_url = cover_image_result[0] if cover_image_result else None
-            cover_image_path = cover_image_result[1] if cover_image_result else None
-            article_summary = cover_image_result[2] if cover_image_result and len(cover_image_result) > 2 else None
-
-            markdown_with_cover = markdown_content
-            if cover_image_path and markdown_content:
-                title_str = outline.get('title', topic)
-                if cover_image_path.startswith('http'):
-                    cover_image_ref = cover_image_path
-                else:
-                    cover_filename = os.path.basename(cover_image_path)
-                    cover_image_ref = f"./images/{cover_filename}"
-                cover_section = f"\n![{title_str} - 架构图]({cover_image_ref})\n\n---\n\n"
-                lines = markdown_content.split('\n')
-                insert_idx = 0
-                for i, line in enumerate(lines):
-                    if line.startswith('## ') and i > 0:
-                        insert_idx = i
-                        break
-                if insert_idx > 0:
-                    lines.insert(insert_idx, cover_section)
-                    markdown_with_cover = '\n'.join(lines)
-                else:
-                    markdown_with_cover = cover_section + markdown_content
-
-            saved_path = None
-            if markdown_content:
-                saved_path = self._save_markdown(
-                    task_id=task_id,
-                    markdown=markdown_content,
-                    outline=outline,
-                    cover_image_path=cover_image_path
-                )
-
-            # 封面动画
-            cover_video_path = None
-            cover_video_enabled = os.environ.get('COVER_VIDEO_ENABLED', 'true').lower() == 'true'
-            if generate_cover_video and cover_image_url and cover_video_enabled:
-                section_images = final_state.get('section_images', [])
-                cover_video_path = self._generate_cover_video(
-                    history_id=task_id,
-                    cover_image_url=cover_image_url,
-                    video_aspect_ratio=video_aspect_ratio,
-                    task_manager=task_manager,
-                    task_id=task_id,
-                    section_images=section_images
-                )
-
-            # 保存历史记录
-            try:
-                from services.database_service import get_db_service
-                import json
-                db_service = get_db_service()
-                
-                # 构建 citations（复用 _run_generation 逻辑）
-                citations = []
-                seen_urls = set()
-                for src_list_key in ('search_results', 'top_references'):
-                    for r in (final_state.get(src_list_key) or []):
-                        url = r.get('url') or r.get('source', '')
-                        if not url or url in seen_urls:
-                            continue
-                        seen_urls.add(url)
-                        try:
-                            from urllib.parse import urlparse
-                            domain = urlparse(url).hostname or ''
-                        except Exception:
-                            domain = ''
-                        citations.append({
-                            'url': url,
-                            'title': r.get('title', ''),
-                            'domain': domain,
-                            'snippet': (r.get('content', '') or r.get('snippet', ''))[:80],
-                        })
-                
-                db_service.save_history(
-                    history_id=task_id,
                     topic=topic,
                     article_type=article_type,
                     target_length=target_length,
-                    markdown_content=markdown_with_cover,
-                    outline=json.dumps(final_state.get('outline') or {}, ensure_ascii=False),
-                    sections_count=len(final_state.get('sections', [])),
-                    code_blocks_count=len(final_state.get('code_blocks', [])),
-                    images_count=len(final_state.get('images', [])),
-                    review_score=final_state.get('review_score', 0),
-                    cover_image=cover_image_path,
-                    cover_video=cover_video_path,
-                    target_sections_count=article_config.get('sections_count'),
-                    target_images_count=article_config.get('images_count'),
-                    target_code_blocks_count=article_config.get('code_blocks_count'),
-                    target_word_count=article_config.get('target_word_count'),
-                    citations=json.dumps(citations, ensure_ascii=False) if citations else None
-                )
-                logger.info(f"历史记录已保存: {task_id}")
-
-                self._send_completion_event(
-                    task_manager=task_manager,
-                    task_id=task_id,
                     final_state=final_state,
-                    markdown=markdown_with_cover,
-                    saved_path=saved_path,
-                    cover_video_path=cover_video_path,
-                    citations=citations,
+                    article_config=article_config,
+                    generate_images=generate_images,
+                    generate_cover_video=generate_cover_video,
+                    video_aspect_ratio=video_aspect_ratio,
+                    task_manager=task_manager,
+                    token_tracker=token_tracker,
+                    task_log=task_log,
                 )
-
-                # 保存博客摘要
-                try:
-                    summary_to_save = article_summary
-                    if not summary_to_save:
-                        summary_to_save = extract_article_summary(
-                            llm_client=self.generator.llm,
-                            title=topic,
-                            content=markdown_with_cover,
-                            max_length=500
-                        )
-                    if summary_to_save:
-                        summary_to_save = summary_to_save[:500]
-                        db_service.update_history_summary(task_id, summary_to_save)
-                except Exception as e:
-                    logger.warning(f"保存博客摘要失败: {e}")
-            except Exception as e:
-                logger.warning(f"保存历史记录失败: {e}")
-                raise RuntimeError(f"保存历史记录失败: {e}") from e
-
-            # Token 追踪
-            token_summary = None
-            if token_tracker:
-                try:
-                    logger.info(token_tracker.format_summary())
-                    token_summary = token_tracker.get_summary()
-                except Exception as e:
-                    logger.warning(f"Token 摘要生成失败: {e}")
-
-            # 任务日志
-            if task_log:
-                try:
-                    task_log.complete(
-                        score=final_state.get('review_score', 0),
-                        word_count=len(final_state.get('final_markdown', '')),
-                        revision_rounds=final_state.get('revision_count', 0),
-                    )
-                    if token_summary:
-                        task_log.token_summary = token_summary
-                    task_log.save()
-                    logger.info(task_log.get_summary())
-                except Exception as e:
-                    logger.warning(f"任务日志保存失败: {e}")
-
-            # 构建 citations
-            citations = []
-            seen_urls = set()
-            for src_list_key in ('search_results', 'top_references'):
-                for r in (final_state.get(src_list_key) or []):
-                    url = r.get('url') or r.get('source', '')
-                    if not url or url in seen_urls:
-                        continue
-                    seen_urls.add(url)
-                    try:
-                        from urllib.parse import urlparse
-                        domain = urlparse(url).hostname or ''
-                    except Exception:
-                        domain = ''
-                    citations.append({
-                        'url': url,
-                        'title': r.get('title', ''),
-                        'domain': domain,
-                        'snippet': (r.get('content', '') or r.get('snippet', ''))[:80],
-                    })
-
-            logger.info(f"博客生成完成（resume）: {task_id}, 保存到: {saved_path}")
+            )
+            logger.info(
+                f"博客生成完成（resume）: {task_id}, 保存到: {result.saved_path}"
+            )
         except Exception as e:
             logger.error(f"博客生成失败（resume）[{task_id}]: {e}", exc_info=True)
             if task_log:
@@ -1836,7 +1381,9 @@ class BlogService:
                 })
             update_queue_status(task_id, "failed", error_msg=str(e))
         finally:
-            if sse_handler:
+            if event_bridge:
+                event_bridge.close()
+            elif sse_handler:
                 for logger_name in sse_logger_names:
                     logging.getLogger(logger_name).removeHandler(sse_handler)
             # 清理按任务分离的文本日志 handler

--- a/backend/services/blog_generator/generator.py
+++ b/backend/services/blog_generator/generator.py
@@ -10,7 +10,7 @@ import uuid
 from concurrent.futures import ThreadPoolExecutor
 from typing import Dict, Any, Optional, Literal, Callable
 
-from langgraph.graph import StateGraph, START, END
+from langgraph.graph import StateGraph
 from langgraph.checkpoint.memory import MemorySaver
 from langgraph.types import interrupt
 
@@ -42,6 +42,8 @@ from .context_management_middleware import ContextManagementMiddleware
 from .parallel import ParallelTaskExecutor, TaskConfig
 from .llm_proxy import TieredLLMProxy
 from .llm_tier_config import get_agent_tier
+from .orchestrator.execution_runner import GraphExecutionRunner
+from .orchestrator.graph_builder import GraphBuilder
 import uuid
 
 logger = logging.getLogger(__name__)
@@ -198,6 +200,7 @@ class BlogGenerator:
         # 构建工作流
         self.workflow = self._build_workflow()
         self.app = None
+        self._execution_runner = GraphExecutionRunner(self)
 
     def _validate_layer(self, layer_name: str, state: Dict[str, Any]):
         """37.12 层间数据契约校验（仅日志警告，不阻断流程）"""
@@ -217,115 +220,7 @@ class BlogGenerator:
         Returns:
             StateGraph 实例
         """
-        workflow = StateGraph(SharedState)
-        
-        # 添加节点（102.10 中间件 + 稳定 SharedState 边界契约）
-        self._add_node(workflow, "researcher", self._researcher_node)
-        self._add_node(workflow, "planner", self._planner_node)
-        self._add_node(workflow, "writer", self._writer_node)
-        # 多轮搜索相关节点
-        self._add_node(workflow, "check_knowledge", self._check_knowledge_node)
-        self._add_node(workflow, "refine_search", self._refine_search_node)
-        self._add_node(workflow, "enhance_with_knowledge", self._enhance_with_knowledge_node)
-        # 追问和审核节点
-        self._add_node(workflow, "questioner", self._questioner_node)
-        self._add_node(workflow, "deepen_content", self._deepen_content_node)
-        self._add_node(workflow, "coder_and_artist", self._coder_and_artist_node)
-        self._add_node(workflow, "cross_section_dedup", self._cross_section_dedup_node)
-        self._add_node(workflow, "section_evaluate", self._section_evaluate_node)
-        self._add_node(workflow, "section_improve", self._section_improve_node)
-        self._add_node(workflow, "consistency_check", self._consistency_check_node)
-        self._add_node(workflow, "reviewer", self._reviewer_node)
-        self._add_node(workflow, "revision", self._revision_node)
-        self._add_node(workflow, "factcheck", self._factcheck_node)
-        self._add_node(workflow, "text_cleanup", self._text_cleanup_node)
-        self._add_node(workflow, "humanizer", self._humanizer_node)
-        self._add_node(workflow, "wait_for_images", self._wait_for_images_node)
-        self._add_node(workflow, "assembler", self._assembler_node)
-        self._add_node(workflow, "summary_generator", self._summary_generator_node)
-        
-        # 定义边
-        workflow.add_edge(START, "researcher")
-        workflow.add_edge("researcher", "planner")
-        workflow.add_edge("planner", "writer")
-        
-        # Writer 后：mini 模式跳过知识空白检查，直接进入 questioner
-        workflow.add_conditional_edges(
-            "writer",
-            self._should_check_knowledge,
-            {
-                "check": "check_knowledge",
-                "skip": "questioner"
-            }
-        )
-        
-        # 条件边：检查后决定是搜索还是继续到 Questioner
-        workflow.add_conditional_edges(
-            "check_knowledge",
-            self._should_refine_search,
-            {
-                "search": "refine_search",
-                "continue": "questioner"
-            }
-        )
-        
-        # 搜索后增强内容，然后回到知识检查
-        workflow.add_edge("refine_search", "enhance_with_knowledge")
-        workflow.add_edge("enhance_with_knowledge", "check_knowledge")
-        
-        # 条件边：追问后决定是深化还是继续
-        workflow.add_conditional_edges(
-            "questioner",
-            self._should_deepen,
-            {
-                "deepen": "deepen_content",
-                "continue": "section_evaluate"  # 进入段落评估
-            }
-        )
-        # 深化后判断是否需要继续追问（避免已达轮数上限仍执行 questioner）
-        workflow.add_conditional_edges(
-            "deepen_content",
-            self._should_continue_questioning,
-            {
-                "questioner": "questioner",
-                "section_evaluate": "section_evaluate"
-            }
-        )
-
-        # 段落评估 → 条件边：需要改进则进入改进节点，否则跳过
-        workflow.add_conditional_edges(
-            "section_evaluate",
-            self._should_improve_sections,
-            {
-                "improve": "section_improve",
-                "continue": "coder_and_artist",
-            }
-        )
-        workflow.add_edge("section_improve", "section_evaluate")  # 改进后重新评估
-        
-        # Coder 和 Artist 并行执行（通过单个节点内部并行实现）
-        workflow.add_edge("coder_and_artist", "cross_section_dedup")
-        workflow.add_edge("cross_section_dedup", "consistency_check")
-        workflow.add_edge("consistency_check", "reviewer")
-        
-        # 条件边：审核后决定是修订还是进入去 AI 味
-        workflow.add_conditional_edges(
-            "reviewer",
-            self._should_revise,
-            {
-                "revision": "revision",
-                "assemble": "factcheck"
-            }
-        )
-        workflow.add_edge("revision", "reviewer")  # 修订后重新审核
-        workflow.add_edge("factcheck", "text_cleanup")  # 事实核查后文本清理
-        workflow.add_edge("text_cleanup", "humanizer")  # 文本清理后去 AI 味
-        workflow.add_edge("humanizer", "wait_for_images")  # 去 AI 味后等待配图
-        workflow.add_edge("wait_for_images", "assembler")  # 配图就绪后组装
-        workflow.add_edge("assembler", "summary_generator")
-        workflow.add_edge("summary_generator", END)
-        
-        return workflow
+        return GraphBuilder(self).build()
 
     def _add_node(self, workflow: StateGraph, node_name: str, handler: Callable) -> None:
         """Register middleware inside the stable state contract boundary."""
@@ -1286,146 +1181,14 @@ class BlogGenerator:
         Returns:
             生成结果
         """
-        if self.app is None:
-            self.compile()
-
-        # 根据 StyleProfile 配置并行执行引擎
-        style = StyleProfile.from_target_length(target_length)
-        self.executor = ParallelTaskExecutor(enable_parallel=style.enable_parallel)
-
-        # 创建 Token 追踪器并注入 LLMService
-        token_tracker = None
-        cost_tracker = None
-        try:
-            import os
-            if os.environ.get('TOKEN_TRACKING_ENABLED', 'true').lower() == 'true':
-                from utils.token_tracker import TokenTracker
-                token_tracker = TokenTracker()
-                self.llm.token_tracker = token_tracker
-            # 41.08 成本追踪增强
-            if os.environ.get('COST_TRACKING_ENABLED', 'false').lower() == 'true':
-                from utils.cost_tracker import CostTracker
-                cost_tracker = CostTracker()
-                self.llm._cost_tracker = cost_tracker
-        except Exception:
-            pass
-
-        # 创建结构化任务日志
-        task_log = None
-        try:
-            import os as _os
-            if _os.environ.get('BLOG_TASK_LOG_ENABLED', 'true').lower() == 'true':
-                from .utils.task_log import BlogTaskLog
-                task_log = BlogTaskLog(
-                    topic=topic,
-                    article_type=article_type,
-                    target_length=target_length,
-                )
-                self.task_log = task_log
-                # 注入到中间件，自动记录每个节点耗时
-                self._task_log_middleware.set_task_log(task_log)
-        except Exception:
-            pass
-
-        # 创建 ToolManager 并注册现有工具（37.09）
-        try:
-            from utils.tool_manager import BlogToolManager
-            tool_manager = BlogToolManager(task_log=task_log)
-            if self.search_service:
-                tool_manager.register(
-                    "web_search", self.search_service.search,
-                    description="搜索互联网获取背景知识", timeout=30,
-                )
-            self.tool_manager = tool_manager
-        except Exception:
-            pass
-
-        # 创建初始状态
-        initial_state = create_initial_state(
+        return self._execution_runner.generate(
             topic=topic,
             article_type=article_type,
             target_audience=target_audience,
             target_length=target_length,
-            source_material=source_material
+            source_material=source_material,
+            on_progress=on_progress,
         )
-
-        logger.info(f"开始生成博客: {topic}")
-        logger.info(f"  类型: {article_type}, 受众: {target_audience}, 长度: {target_length}")
-        
-        # 执行工作流
-        config = self._build_config(initial_state)
-        logger.info(f"[RecursionBudget] limit={config['recursion_limit']}")
-
-        try:
-            final_state = self.app.invoke(initial_state, config)
-            
-            logger.info("博客生成完成!")
-
-            # 输出 Token 用量摘要
-            token_summary = None
-            if token_tracker:
-                logger.info(token_tracker.format_summary())
-                token_summary = token_tracker.get_summary()
-
-            # 41.08 成本摘要
-            cost_summary = None
-            if cost_tracker:
-                logger.info(cost_tracker.format_summary())
-                cost_summary = cost_tracker.get_summary()
-
-            # 完成任务日志
-            if task_log:
-                task_log.complete(
-                    score=final_state.get('review_score', 0),
-                    word_count=len(final_state.get('final_markdown', '')),
-                    revision_rounds=final_state.get('revision_count', 0),
-                )
-                if token_summary:
-                    task_log.token_summary = token_summary
-                try:
-                    task_log.save()
-                except Exception as save_err:
-                    logger.warning(f"任务日志保存失败: {save_err}")
-                logger.info(task_log.get_summary())
-
-            result = {
-                "success": True,
-                "markdown": final_state.get('final_markdown', ''),
-                "outline": final_state.get('outline', {}),
-                "sections_count": len(final_state.get('sections', [])),
-                "images_count": len(final_state.get('images', [])),
-                "code_blocks_count": len(final_state.get('code_blocks', [])),
-                "review_score": final_state.get('review_score', 0),
-                "seo_keywords": final_state.get('seo_keywords', []),
-                "social_summary": final_state.get('social_summary', ''),
-                "meta_description": final_state.get('meta_description', ''),
-                "error": None
-            }
-            if token_summary:
-                result["token_summary"] = token_summary
-            if cost_summary:
-                result["cost_summary"] = cost_summary
-
-            # 37.14/37.16 博客衍生物生成（Skill 后处理）
-            derivatives = self._run_derivative_skills(final_state)
-            if derivatives:
-                result["derivatives"] = derivatives
-
-            return result
-            
-        except Exception as e:
-            logger.error(f"博客生成失败: {e}", exc_info=True)
-            if task_log:
-                task_log.fail(str(e))
-                try:
-                    task_log.save()
-                except Exception:
-                    pass
-            return {
-                "success": False,
-                "markdown": "",
-                "error": str(e)
-            }
     
     async def generate_stream(
         self,
@@ -1448,22 +1211,11 @@ class BlogGenerator:
         Yields:
             生成进度和中间结果
         """
-        if self.app is None:
-            self.compile()
-        
-        initial_state = create_initial_state(
+        async for event in self._execution_runner.generate_stream(
             topic=topic,
             article_type=article_type,
             target_audience=target_audience,
             target_length=target_length,
-            source_material=source_material
-        )
-
-        config = self._build_config(initial_state)
-        logger.info(f"[RecursionBudget] limit={config['recursion_limit']}")
-        for event in self.app.stream(initial_state, config):
-            for node_name, state in event.items():
-                yield {
-                    "stage": node_name,
-                    "state": state
-                }
+            source_material=source_material,
+        ):
+            yield event

--- a/backend/services/blog_generator/lifecycle/__init__.py
+++ b/backend/services/blog_generator/lifecycle/__init__.py
@@ -1,0 +1,16 @@
+"""Task lifecycle and result finalization helpers."""
+
+from .result_pipeline import (
+    GenerationResult,
+    GenerationResultPipeline,
+    GenerationResultRequest,
+)
+from .task_events import SSELogHandler, TaskEventBridge
+
+__all__ = [
+    "GenerationResult",
+    "GenerationResultPipeline",
+    "GenerationResultRequest",
+    "SSELogHandler",
+    "TaskEventBridge",
+]

--- a/backend/services/blog_generator/lifecycle/result_pipeline.py
+++ b/backend/services/blog_generator/lifecycle/result_pipeline.py
@@ -1,0 +1,270 @@
+"""Shared post-stream generation result handling."""
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+from urllib.parse import urlparse
+
+
+logger = logging.getLogger("services.blog_generator.blog_service")
+
+
+@dataclass
+class GenerationResultRequest:
+    task_id: str
+    topic: str
+    article_type: str
+    target_length: str
+    final_state: Dict[str, Any]
+    article_config: Dict[str, Any]
+    generate_images: bool
+    generate_cover_video: bool
+    video_aspect_ratio: str
+    task_manager: Any = None
+    token_tracker: Any = None
+    task_log: Any = None
+    record_memory: bool = False
+
+
+@dataclass
+class GenerationResult:
+    markdown: str
+    saved_path: Optional[str]
+    cover_video_path: Optional[str]
+    citations: list
+
+
+class GenerationResultPipeline:
+    def __init__(self, service):
+        self.service = service
+
+    def finalize(self, request: GenerationResultRequest) -> GenerationResult:
+        final_state = request.final_state
+        markdown_content = self.service._validate_final_state(final_state)
+        outline = final_state.get("outline") or {}
+        cover_image_result = self._generate_cover(request, outline, markdown_content)
+        cover_image_url = cover_image_result[0] if cover_image_result else None
+        cover_image_path = cover_image_result[1] if cover_image_result else None
+        article_summary = (
+            cover_image_result[2]
+            if cover_image_result and len(cover_image_result) > 2
+            else None
+        )
+        markdown_with_cover = self._insert_cover(
+            markdown_content, outline, request.topic, cover_image_path
+        )
+        saved_path = self.service._save_markdown(
+            task_id=request.task_id,
+            markdown=markdown_content,
+            outline=outline,
+            cover_image_path=cover_image_path,
+        )
+        cover_video_path = self._generate_video(request, cover_image_url)
+        citations = self._build_citations(final_state)
+
+        self._persist_and_complete(
+            request=request,
+            markdown=markdown_with_cover,
+            saved_path=saved_path,
+            cover_image_path=cover_image_path,
+            cover_video_path=cover_video_path,
+            article_summary=article_summary,
+            citations=citations,
+        )
+        self._complete_tracking(request)
+
+        return GenerationResult(
+            markdown=markdown_with_cover,
+            saved_path=saved_path,
+            cover_video_path=cover_video_path,
+            citations=citations,
+        )
+
+    def _generate_cover(self, request, outline, markdown_content):
+        if not request.generate_images:
+            logger.info("图片生成已禁用，跳过封面图")
+            return None
+        return self.service._generate_cover_image(
+            title=outline.get("title", request.topic),
+            topic=request.topic,
+            full_content=markdown_content,
+            task_manager=request.task_manager,
+            task_id=request.task_id,
+            image_style=request.final_state.get("image_style", ""),
+            video_aspect_ratio=(
+                request.video_aspect_ratio if request.generate_cover_video else "16:9"
+            ),
+        )
+
+    @staticmethod
+    def _insert_cover(markdown, outline, topic, cover_image_path):
+        if not cover_image_path or not markdown:
+            return markdown
+        title = outline.get("title", topic)
+        if cover_image_path.startswith("http"):
+            cover_image_ref = cover_image_path
+        else:
+            cover_image_ref = f"./images/{os.path.basename(cover_image_path)}"
+        cover_section = f"\n![{title} - 架构图]({cover_image_ref})\n\n---\n\n"
+        lines = markdown.split("\n")
+        insert_idx = 0
+        for index, line in enumerate(lines):
+            if line.startswith("## ") and index > 0:
+                insert_idx = index
+                break
+        if insert_idx > 0:
+            lines.insert(insert_idx, cover_section)
+            return "\n".join(lines)
+        return cover_section + markdown
+
+    def _generate_video(self, request, cover_image_url):
+        enabled = os.environ.get("COVER_VIDEO_ENABLED", "true").lower() == "true"
+        if not (request.generate_cover_video and cover_image_url and enabled):
+            return None
+        return self.service._generate_cover_video(
+            history_id=request.task_id,
+            cover_image_url=cover_image_url,
+            video_aspect_ratio=request.video_aspect_ratio,
+            task_manager=request.task_manager,
+            task_id=request.task_id,
+            section_images=request.final_state.get("section_images", []),
+        )
+
+    @staticmethod
+    def _build_citations(final_state):
+        citations = []
+        seen_urls = set()
+        for source_key in ("search_results", "top_references"):
+            for reference in final_state.get(source_key) or []:
+                url = reference.get("url") or reference.get("source", "")
+                if not url or url in seen_urls:
+                    continue
+                seen_urls.add(url)
+                try:
+                    domain = urlparse(url).hostname or ""
+                except Exception:
+                    domain = ""
+                citations.append(
+                    {
+                        "url": url,
+                        "title": reference.get("title", ""),
+                        "domain": domain,
+                        "snippet": (
+                            reference.get("content", "")
+                            or reference.get("snippet", "")
+                        )[:80],
+                    }
+                )
+        return citations
+
+    def _persist_and_complete(
+        self,
+        *,
+        request,
+        markdown,
+        saved_path,
+        cover_image_path,
+        cover_video_path,
+        article_summary,
+        citations,
+    ):
+        try:
+            from services.database_service import get_db_service
+
+            db_service = get_db_service()
+            final_state = request.final_state
+            article_config = request.article_config
+            db_service.save_history(
+                history_id=request.task_id,
+                topic=request.topic,
+                article_type=request.article_type,
+                target_length=request.target_length,
+                markdown_content=markdown,
+                outline=json.dumps(final_state.get("outline") or {}, ensure_ascii=False),
+                sections_count=len(final_state.get("sections", [])),
+                code_blocks_count=len(final_state.get("code_blocks", [])),
+                images_count=len(final_state.get("images", [])),
+                review_score=final_state.get("review_score", 0),
+                cover_image=cover_image_path,
+                cover_video=cover_video_path,
+                target_sections_count=article_config.get("sections_count"),
+                target_images_count=article_config.get("images_count"),
+                target_code_blocks_count=article_config.get("code_blocks_count"),
+                target_word_count=article_config.get("target_word_count"),
+                citations=json.dumps(citations, ensure_ascii=False) if citations else None,
+            )
+            logger.info(f"历史记录已保存: {request.task_id}")
+            self.service._send_completion_event(
+                task_manager=request.task_manager,
+                task_id=request.task_id,
+                final_state=final_state,
+                markdown=markdown,
+                saved_path=saved_path,
+                cover_video_path=cover_video_path,
+                citations=citations,
+            )
+            self._record_memory(request)
+            self._save_summary(request, db_service, markdown, article_summary)
+        except Exception as error:
+            logger.warning(f"保存历史记录失败: {error}")
+            raise RuntimeError(f"保存历史记录失败: {error}") from error
+
+    def _record_memory(self, request):
+        storage = getattr(self.service.generator, "_memory_storage", None)
+        if not request.record_memory or not storage:
+            return
+        try:
+            storage.add_fact(
+                "default",
+                f"生成了关于 {request.topic} 的 {request.article_type} 文章",
+                category="behavior",
+                confidence=0.8,
+                source=f"task:{request.task_id}",
+            )
+        except Exception as error:
+            logger.debug(f"记忆记录跳过: {error}")
+
+    def _save_summary(self, request, db_service, markdown, article_summary):
+        try:
+            summary = article_summary
+            if not summary:
+                from services.blog_generator import blog_service
+
+                summary = blog_service.extract_article_summary(
+                    llm_client=self.service.generator.llm,
+                    title=request.topic,
+                    content=markdown,
+                    max_length=500,
+                )
+            if summary:
+                db_service.update_history_summary(request.task_id, summary[:500])
+                if request.record_memory:
+                    logger.info(f"博客摘要已保存: {request.task_id}")
+        except Exception as error:
+            logger.warning(f"保存博客摘要失败: {error}")
+
+    @staticmethod
+    def _complete_tracking(request):
+        token_summary = None
+        if request.token_tracker:
+            try:
+                logger.info(request.token_tracker.format_summary())
+                token_summary = request.token_tracker.get_summary()
+            except Exception as error:
+                logger.warning(f"Token 摘要生成失败: {error}")
+        if request.task_log:
+            try:
+                final_state = request.final_state
+                request.task_log.complete(
+                    score=final_state.get("review_score", 0),
+                    word_count=len(final_state.get("final_markdown", "")),
+                    revision_rounds=final_state.get("revision_count", 0),
+                )
+                if token_summary:
+                    request.task_log.token_summary = token_summary
+                request.task_log.save()
+                logger.info(request.task_log.get_summary())
+            except Exception as error:
+                logger.warning(f"任务日志保存失败: {error}")

--- a/backend/services/blog_generator/lifecycle/task_events.py
+++ b/backend/services/blog_generator/lifecycle/task_events.py
@@ -1,0 +1,152 @@
+"""Task-scoped logging and event dependency wiring."""
+
+import json
+import logging
+import re
+
+
+LOGGER_NAMES = (
+    "services.blog_generator.generator",
+    "services.blog_generator.agents.researcher",
+    "services.blog_generator.agents.planner",
+    "services.blog_generator.agents.writer",
+    "services.blog_generator.agents.questioner",
+    "services.blog_generator.agents.coder",
+    "services.blog_generator.agents.artist",
+    "services.blog_generator.agents.reviewer",
+    "services.blog_generator.agents.assembler",
+    "services.blog_generator.agents.search_coordinator",
+    "services.blog_generator.services.search_service",
+    "services.media.image_service",
+)
+
+
+class SSELogHandler(logging.Handler):
+    """Forward generation logs and recognized search events to a task stream."""
+
+    def __init__(self, task_manager, task_id):
+        super().__init__()
+        self.task_manager = task_manager
+        self.task_id = task_id
+
+    def emit(self, record):
+        if self.task_manager and record.name.startswith("services.blog_generator"):
+            if not self.task_manager.get_queue(self.task_id):
+                logging.getLogger(record.name).removeHandler(self)
+                return
+            msg = self.format(record)
+            self.task_manager.send_event(
+                self.task_id,
+                "log",
+                {
+                    "level": record.levelname,
+                    "logger": record.name.split(".")[-1],
+                    "message": msg,
+                },
+            )
+            self._emit_structured_search_event(msg)
+
+    def _emit_structured_search_event(self, msg):
+        try:
+            match = re.search(r"(?:Web Search 搜索|智能.*搜索)[：:]\s*(.+)", msg)
+            if match:
+                self.task_manager.send_event(
+                    self.task_id,
+                    "result",
+                    {
+                        "type": "search_started",
+                        "data": {"query": match.group(1).strip()},
+                    },
+                )
+                return
+            if "请求参数" in msg and "search_query" in msg:
+                payload_match = re.search(r"\{.*\}", msg)
+                if payload_match:
+                    try:
+                        payload = json.loads(payload_match.group(0))
+                        self.task_manager.send_event(
+                            self.task_id,
+                            "result",
+                            {
+                                "type": "search_started",
+                                "data": {"query": payload.get("search_query", "")},
+                            },
+                        )
+                    except json.JSONDecodeError:
+                        pass
+                return
+            crawl_match = re.search(r"深度抓取完成[：:]\s*(\d+)", msg)
+            if crawl_match:
+                self.task_manager.send_event(
+                    self.task_id,
+                    "result",
+                    {
+                        "type": "crawl_completed",
+                        "data": {"count": int(crawl_match.group(1))},
+                    },
+                )
+                return
+            if "智能搜索完成" in msg:
+                self.task_manager.send_event(
+                    self.task_id,
+                    "result",
+                    {"type": "search_completed", "data": {"message": msg}},
+                )
+        except Exception:
+            pass
+
+
+class TaskEventBridge:
+    """Attach task logging and inject task-aware collaborators."""
+
+    def __init__(self, generator, task_manager, task_id):
+        self.generator = generator
+        self.task_manager = task_manager
+        self.task_id = task_id
+        self.logger_names = LOGGER_NAMES
+        self.handler = None
+
+    def attach(self):
+        if not self.task_manager or self.handler is not None:
+            return self.handler
+        self.handler = SSELogHandler(self.task_manager, self.task_id)
+        self.handler.setLevel(logging.INFO)
+        self.handler.setFormatter(logging.Formatter("%(message)s"))
+        for logger_name in self.logger_names:
+            logging.getLogger(logger_name).addHandler(self.handler)
+        return self.handler
+
+    def inject_dependencies(self):
+        if not self.task_manager:
+            return
+        try:
+            llm = self.generator.llm
+            llm.task_manager = self.task_manager
+            llm.task_id = self.task_id
+            from utils.llm_logger import LLMCallLogger
+
+            llm.llm_logger = LLMCallLogger(self.task_id)
+        except Exception:
+            pass
+        try:
+            researcher = self.generator.researcher
+            researcher.task_manager = self.task_manager
+            researcher.task_id = self.task_id
+            if researcher.search_service:
+                researcher.search_service.task_manager = self.task_manager
+                researcher.search_service.task_id = self.task_id
+        except Exception:
+            pass
+        try:
+            writer = self.generator.writer
+            writer.task_manager = self.task_manager
+            writer.task_id = self.task_id
+        except Exception:
+            pass
+
+    def close(self):
+        if self.handler is None:
+            return
+        for logger_name in self.logger_names:
+            logging.getLogger(logger_name).removeHandler(self.handler)
+        self.handler = None

--- a/backend/services/blog_generator/orchestrator/execution_runner.py
+++ b/backend/services/blog_generator/orchestrator/execution_runner.py
@@ -1,0 +1,179 @@
+"""Compiled graph execution entry points."""
+
+import logging
+import os
+from typing import Any, Callable, Dict
+
+from ..parallel import ParallelTaskExecutor
+from ..schemas.state import create_initial_state
+from ..style_profile import StyleProfile
+
+
+logger = logging.getLogger("services.blog_generator.generator")
+
+
+class GraphExecutionRunner:
+    def __init__(self, generator):
+        self.generator = generator
+
+    def generate(
+        self,
+        topic: str,
+        article_type: str = "tutorial",
+        target_audience: str = "intermediate",
+        target_length: str = "medium",
+        source_material: str = None,
+        on_progress: Callable[[str, str], None] = None,
+    ) -> Dict[str, Any]:
+        generator = self.generator
+        if generator.app is None:
+            generator.compile()
+
+        style = StyleProfile.from_target_length(target_length)
+        generator.executor = ParallelTaskExecutor(enable_parallel=style.enable_parallel)
+
+        token_tracker = None
+        cost_tracker = None
+        try:
+            if os.environ.get("TOKEN_TRACKING_ENABLED", "true").lower() == "true":
+                from utils.token_tracker import TokenTracker
+
+                token_tracker = TokenTracker()
+                generator.llm.token_tracker = token_tracker
+            if os.environ.get("COST_TRACKING_ENABLED", "false").lower() == "true":
+                from utils.cost_tracker import CostTracker
+
+                cost_tracker = CostTracker()
+                generator.llm._cost_tracker = cost_tracker
+        except Exception:
+            pass
+
+        task_log = None
+        try:
+            if os.environ.get("BLOG_TASK_LOG_ENABLED", "true").lower() == "true":
+                from ..utils.task_log import BlogTaskLog
+
+                task_log = BlogTaskLog(
+                    topic=topic,
+                    article_type=article_type,
+                    target_length=target_length,
+                )
+                generator.task_log = task_log
+                generator._task_log_middleware.set_task_log(task_log)
+        except Exception:
+            pass
+
+        try:
+            from utils.tool_manager import BlogToolManager
+
+            tool_manager = BlogToolManager(task_log=task_log)
+            if generator.search_service:
+                tool_manager.register(
+                    "web_search",
+                    generator.search_service.search,
+                    description="搜索互联网获取背景知识",
+                    timeout=30,
+                )
+            generator.tool_manager = tool_manager
+        except Exception:
+            pass
+
+        initial_state = create_initial_state(
+            topic=topic,
+            article_type=article_type,
+            target_audience=target_audience,
+            target_length=target_length,
+            source_material=source_material,
+        )
+        logger.info(f"开始生成博客: {topic}")
+        logger.info(
+            f"  类型: {article_type}, 受众: {target_audience}, 长度: {target_length}"
+        )
+
+        config = generator._build_config(initial_state)
+        logger.info(f"[RecursionBudget] limit={config['recursion_limit']}")
+
+        try:
+            final_state = generator.app.invoke(initial_state, config)
+            logger.info("博客生成完成!")
+
+            token_summary = None
+            if token_tracker:
+                logger.info(token_tracker.format_summary())
+                token_summary = token_tracker.get_summary()
+
+            cost_summary = None
+            if cost_tracker:
+                logger.info(cost_tracker.format_summary())
+                cost_summary = cost_tracker.get_summary()
+
+            if task_log:
+                task_log.complete(
+                    score=final_state.get("review_score", 0),
+                    word_count=len(final_state.get("final_markdown", "")),
+                    revision_rounds=final_state.get("revision_count", 0),
+                )
+                if token_summary:
+                    task_log.token_summary = token_summary
+                try:
+                    task_log.save()
+                except Exception as save_err:
+                    logger.warning(f"任务日志保存失败: {save_err}")
+                logger.info(task_log.get_summary())
+
+            result = {
+                "success": True,
+                "markdown": final_state.get("final_markdown", ""),
+                "outline": final_state.get("outline", {}),
+                "sections_count": len(final_state.get("sections", [])),
+                "images_count": len(final_state.get("images", [])),
+                "code_blocks_count": len(final_state.get("code_blocks", [])),
+                "review_score": final_state.get("review_score", 0),
+                "seo_keywords": final_state.get("seo_keywords", []),
+                "social_summary": final_state.get("social_summary", ""),
+                "meta_description": final_state.get("meta_description", ""),
+                "error": None,
+            }
+            if token_summary:
+                result["token_summary"] = token_summary
+            if cost_summary:
+                result["cost_summary"] = cost_summary
+
+            derivatives = generator._run_derivative_skills(final_state)
+            if derivatives:
+                result["derivatives"] = derivatives
+            return result
+        except Exception as error:
+            logger.error(f"博客生成失败: {error}", exc_info=True)
+            if task_log:
+                task_log.fail(str(error))
+                try:
+                    task_log.save()
+                except Exception:
+                    pass
+            return {"success": False, "markdown": "", "error": str(error)}
+
+    async def generate_stream(
+        self,
+        topic: str,
+        article_type: str = "tutorial",
+        target_audience: str = "intermediate",
+        target_length: str = "medium",
+        source_material: str = None,
+    ):
+        generator = self.generator
+        if generator.app is None:
+            generator.compile()
+
+        initial_state = create_initial_state(
+            topic=topic,
+            article_type=article_type,
+            target_audience=target_audience,
+            target_length=target_length,
+            source_material=source_material,
+        )
+        config = generator._build_config(initial_state)
+        logger.info(f"[RecursionBudget] limit={config['recursion_limit']}")
+        for event in generator.app.stream(initial_state, config):
+            for node_name, state in event.items():
+                yield {"stage": node_name, "state": state}

--- a/backend/services/blog_generator/orchestrator/graph_builder.py
+++ b/backend/services/blog_generator/orchestrator/graph_builder.py
@@ -1,0 +1,89 @@
+"""LangGraph workflow construction."""
+
+from langgraph.graph import END, START, StateGraph
+
+from ..schemas.state import SharedState
+
+
+class GraphBuilder:
+    def __init__(self, generator):
+        self.generator = generator
+
+    def build(self):
+        generator = self.generator
+        workflow = StateGraph(SharedState)
+
+        nodes = (
+            ("researcher", generator._researcher_node),
+            ("planner", generator._planner_node),
+            ("writer", generator._writer_node),
+            ("check_knowledge", generator._check_knowledge_node),
+            ("refine_search", generator._refine_search_node),
+            ("enhance_with_knowledge", generator._enhance_with_knowledge_node),
+            ("questioner", generator._questioner_node),
+            ("deepen_content", generator._deepen_content_node),
+            ("coder_and_artist", generator._coder_and_artist_node),
+            ("cross_section_dedup", generator._cross_section_dedup_node),
+            ("section_evaluate", generator._section_evaluate_node),
+            ("section_improve", generator._section_improve_node),
+            ("consistency_check", generator._consistency_check_node),
+            ("reviewer", generator._reviewer_node),
+            ("revision", generator._revision_node),
+            ("factcheck", generator._factcheck_node),
+            ("text_cleanup", generator._text_cleanup_node),
+            ("humanizer", generator._humanizer_node),
+            ("wait_for_images", generator._wait_for_images_node),
+            ("assembler", generator._assembler_node),
+            ("summary_generator", generator._summary_generator_node),
+        )
+        for node_name, handler in nodes:
+            generator._add_node(workflow, node_name, handler)
+
+        workflow.add_edge(START, "researcher")
+        workflow.add_edge("researcher", "planner")
+        workflow.add_edge("planner", "writer")
+        workflow.add_conditional_edges(
+            "writer",
+            generator._should_check_knowledge,
+            {"check": "check_knowledge", "skip": "questioner"},
+        )
+        workflow.add_conditional_edges(
+            "check_knowledge",
+            generator._should_refine_search,
+            {"search": "refine_search", "continue": "questioner"},
+        )
+        workflow.add_edge("refine_search", "enhance_with_knowledge")
+        workflow.add_edge("enhance_with_knowledge", "check_knowledge")
+        workflow.add_conditional_edges(
+            "questioner",
+            generator._should_deepen,
+            {"deepen": "deepen_content", "continue": "section_evaluate"},
+        )
+        workflow.add_conditional_edges(
+            "deepen_content",
+            generator._should_continue_questioning,
+            {"questioner": "questioner", "section_evaluate": "section_evaluate"},
+        )
+        workflow.add_conditional_edges(
+            "section_evaluate",
+            generator._should_improve_sections,
+            {"improve": "section_improve", "continue": "coder_and_artist"},
+        )
+        workflow.add_edge("section_improve", "section_evaluate")
+        workflow.add_edge("coder_and_artist", "cross_section_dedup")
+        workflow.add_edge("cross_section_dedup", "consistency_check")
+        workflow.add_edge("consistency_check", "reviewer")
+        workflow.add_conditional_edges(
+            "reviewer",
+            generator._should_revise,
+            {"revision": "revision", "assemble": "factcheck"},
+        )
+        workflow.add_edge("revision", "reviewer")
+        workflow.add_edge("factcheck", "text_cleanup")
+        workflow.add_edge("text_cleanup", "humanizer")
+        workflow.add_edge("humanizer", "wait_for_images")
+        workflow.add_edge("wait_for_images", "assembler")
+        workflow.add_edge("assembler", "summary_generator")
+        workflow.add_edge("summary_generator", END)
+
+        return workflow

--- a/backend/tests/architecture/test_generation_orchestration_boundaries.py
+++ b/backend/tests/architecture/test_generation_orchestration_boundaries.py
@@ -1,0 +1,67 @@
+import ast
+from pathlib import Path
+
+
+BACKEND_ROOT = Path(__file__).resolve().parents[2]
+LIFECYCLE_ROOT = BACKEND_ROOT / "services" / "blog_generator" / "lifecycle"
+ORCHESTRATOR_ROOT = BACKEND_ROOT / "services" / "blog_generator" / "orchestrator"
+
+
+def _top_level_imports(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    imports = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.update(alias.name.split(".", 1)[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imports.add(node.module.split(".", 1)[0])
+    return imports
+
+
+def _method_calls(path: Path, class_name: str, method_name: str) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            for member in node.body:
+                if isinstance(member, (ast.FunctionDef, ast.AsyncFunctionDef)) and member.name == method_name:
+                    return {
+                        call.func.attr
+                        for call in ast.walk(member)
+                        if isinstance(call, ast.Call) and isinstance(call.func, ast.Attribute)
+                    }
+    raise AssertionError(f"Missing {class_name}.{method_name}")
+
+
+def test_extracted_orchestration_does_not_depend_on_api_or_flask():
+    violations = []
+    paths = [*LIFECYCLE_ROOT.glob("*.py")]
+    paths.extend(
+        ORCHESTRATOR_ROOT / name
+        for name in ("graph_builder.py", "execution_runner.py")
+    )
+
+    for path in paths:
+        illegal = _top_level_imports(path) & {"api", "routes", "flask"}
+        if illegal:
+            violations.append(f"{path.relative_to(BACKEND_ROOT)}: {sorted(illegal)}")
+
+    assert not violations, "Invalid orchestration dependencies:\n" + "\n".join(
+        violations
+    )
+
+
+def test_generator_facade_does_not_build_or_execute_graph_directly():
+    path = BACKEND_ROOT / "services" / "blog_generator" / "generator.py"
+
+    assert _method_calls(path, "BlogGenerator", "_build_workflow") == {"build"}
+    assert "invoke" not in _method_calls(path, "BlogGenerator", "generate")
+    assert "stream" not in _method_calls(path, "BlogGenerator", "generate_stream")
+
+
+def test_blog_service_generation_paths_delegate_result_finalization():
+    path = BACKEND_ROOT / "services" / "blog_generator" / "blog_service.py"
+
+    for method_name in ("_run_generation", "_run_resume"):
+        calls = _method_calls(path, "BlogService", method_name)
+        assert "finalize" in calls
+        assert "save_history" not in calls

--- a/backend/tests/architecture/test_shared_state_contract_boundaries.py
+++ b/backend/tests/architecture/test_shared_state_contract_boundaries.py
@@ -45,23 +45,34 @@ def test_shared_state_uses_named_aliases_for_stable_payloads():
 
 
 def test_contract_nodes_use_the_single_registration_boundary():
-    tree = ast.parse(
+    generator_tree = ast.parse(
         (BACKEND_ROOT / "services/blog_generator/generator.py").read_text()
     )
-    build_workflow = _function(tree, "_build_workflow")
+    builder_tree = ast.parse(
+        (
+            BACKEND_ROOT
+            / "services/blog_generator/orchestrator/graph_builder.py"
+        ).read_text()
+    )
+    build_workflow = _function(builder_tree, "build")
     registered = {
-        call.args[1].value
-        for call in ast.walk(build_workflow)
-        if isinstance(call, ast.Call)
-        and isinstance(call.func, ast.Attribute)
-        and call.func.attr == "_add_node"
-        and len(call.args) >= 2
-        and isinstance(call.args[1], ast.Constant)
+        item.elts[0].value
+        for node in build_workflow.body
+        if isinstance(node, ast.Assign)
+        and any(
+            isinstance(target, ast.Name) and target.id == "nodes"
+            for target in node.targets
+        )
+        and isinstance(node.value, (ast.Tuple, ast.List))
+        for item in node.value.elts
+        if isinstance(item, (ast.Tuple, ast.List))
+        and item.elts
+        and isinstance(item.elts[0], ast.Constant)
     }
 
     assert set(NODE_STATE_CONTRACTS) <= registered
 
-    add_node = _function(tree, "_add_node")
+    add_node = _function(generator_tree, "_add_node")
     called_functions = {
         call.func.id
         for call in ast.walk(add_node)

--- a/backend/tests/unit/test_generation_orchestration_contracts.py
+++ b/backend/tests/unit/test_generation_orchestration_contracts.py
@@ -1,0 +1,336 @@
+import inspect
+import logging
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from services.blog_generator.blog_service import BlogService
+from services.blog_generator.generator import BlogGenerator
+from services.blog_generator.lifecycle.result_pipeline import (
+    GenerationResultPipeline,
+    GenerationResultRequest,
+)
+from services.blog_generator.lifecycle.task_events import TaskEventBridge
+from services.blog_generator.orchestrator.execution_runner import GraphExecutionRunner
+from services.blog_generator.orchestrator.graph_builder import GraphBuilder
+
+
+def test_blog_service_preserves_generation_facade_signatures():
+    expected = {
+        "generate_sync": "(self, topic: str, article_type: str = 'tutorial', target_audience: str = 'intermediate', target_length: str = 'medium', source_material: str = None) -> Dict[str, Any]",
+        "generate_async": "(self, task_id: str, topic: str, article_type: str = 'tutorial', target_audience: str = 'intermediate', audience_adaptation: str = 'default', target_length: str = 'medium', source_material: str = None, document_ids: list = None, document_knowledge: list = None, image_style: str = '', generate_images: bool = True, generate_cover_video: bool = False, video_aspect_ratio: str = '16:9', custom_config: dict = None, deep_thinking: bool = False, background_investigation: bool = True, interactive: bool = False, task_manager=None, app=None)",
+        "_run_generation": "(self, task_id: str, topic: str, article_type: str, target_audience: str, audience_adaptation: str, target_length: str, source_material: str, document_ids: list = None, document_knowledge: list = None, image_style: str = '', generate_images: bool = True, generate_cover_video: bool = False, video_aspect_ratio: str = '16:9', custom_config: dict = None, deep_thinking: bool = False, background_investigation: bool = True, interactive: bool = False, task_manager=None)",
+        "_run_resume": "(self, task_id: str, resume_value, config: dict, task_manager=None, task_info: dict = None)",
+        "_generate_cover_image": "(self, title: str, topic: str, full_content: str = '', task_manager=None, task_id: str = None, image_style: str = '', video_aspect_ratio: str = '16:9') -> Optional[tuple]",
+        "_generate_cover_video": "(self, history_id: str, cover_image_url: str, video_aspect_ratio: str = '16:9', task_manager=None, task_id: str = None, section_images: list = None) -> Optional[str]",
+        "_save_markdown": "(self, task_id: str, markdown: str, outline: Dict[str, Any], cover_image_path: Optional[str] = None) -> Optional[str]",
+    }
+
+    assert {
+        name: str(inspect.signature(BlogService.__dict__[name])) for name in expected
+    } == expected
+
+
+def test_blog_generator_preserves_build_and_execution_signatures():
+    expected = {
+        "_build_workflow": "(self) -> langgraph.graph.state.StateGraph",
+        "compile": "(self, checkpointer=None)",
+        "generate": "(self, topic: str, article_type: str = 'tutorial', target_audience: str = 'intermediate', target_length: str = 'medium', source_material: str = None, on_progress: Callable[[str, str], NoneType] = None) -> Dict[str, Any]",
+        "generate_stream": "(self, topic: str, article_type: str = 'tutorial', target_audience: str = 'intermediate', target_length: str = 'medium', source_material: str = None)",
+    }
+
+    assert {
+        name: str(inspect.signature(BlogGenerator.__dict__[name])) for name in expected
+    } == expected
+
+
+def test_graph_builder_preserves_workflow_topology():
+    generator = BlogGenerator(MagicMock())
+
+    workflow = GraphBuilder(generator).build()
+
+    assert set(workflow.nodes) == {
+        "researcher",
+        "planner",
+        "writer",
+        "check_knowledge",
+        "refine_search",
+        "enhance_with_knowledge",
+        "questioner",
+        "deepen_content",
+        "coder_and_artist",
+        "cross_section_dedup",
+        "section_evaluate",
+        "section_improve",
+        "consistency_check",
+        "reviewer",
+        "revision",
+        "factcheck",
+        "text_cleanup",
+        "humanizer",
+        "wait_for_images",
+        "assembler",
+        "summary_generator",
+    }
+    assert set(workflow.edges) == {
+        ("__start__", "researcher"),
+        ("researcher", "planner"),
+        ("planner", "writer"),
+        ("refine_search", "enhance_with_knowledge"),
+        ("enhance_with_knowledge", "check_knowledge"),
+        ("section_improve", "section_evaluate"),
+        ("coder_and_artist", "cross_section_dedup"),
+        ("cross_section_dedup", "consistency_check"),
+        ("consistency_check", "reviewer"),
+        ("revision", "reviewer"),
+        ("factcheck", "text_cleanup"),
+        ("text_cleanup", "humanizer"),
+        ("humanizer", "wait_for_images"),
+        ("wait_for_images", "assembler"),
+        ("assembler", "summary_generator"),
+        ("summary_generator", "__end__"),
+    }
+    assert {
+        source: {name: branch.ends for name, branch in branches.items()}
+        for source, branches in workflow.branches.items()
+    } == {
+        "writer": {
+            "_should_check_knowledge": {
+                "check": "check_knowledge",
+                "skip": "questioner",
+            }
+        },
+        "check_knowledge": {
+            "_should_refine_search": {
+                "search": "refine_search",
+                "continue": "questioner",
+            }
+        },
+        "questioner": {
+            "_should_deepen": {
+                "deepen": "deepen_content",
+                "continue": "section_evaluate",
+            }
+        },
+        "deepen_content": {
+            "_should_continue_questioning": {
+                "questioner": "questioner",
+                "section_evaluate": "section_evaluate",
+            }
+        },
+        "section_evaluate": {
+            "_should_improve_sections": {
+                "improve": "section_improve",
+                "continue": "coder_and_artist",
+            }
+        },
+        "reviewer": {
+            "_should_revise": {
+                "revision": "revision",
+                "assemble": "factcheck",
+            }
+        },
+    }
+
+
+def test_task_event_bridge_attaches_injects_and_closes_idempotently():
+    task_manager = MagicMock()
+    task_manager.get_queue.return_value = object()
+    generator = SimpleNamespace(
+        llm=SimpleNamespace(),
+        researcher=SimpleNamespace(search_service=SimpleNamespace()),
+        writer=SimpleNamespace(),
+    )
+    bridge = TaskEventBridge(generator, task_manager, "task-1")
+
+    bridge.attach()
+    bridge.inject_dependencies()
+    handler = bridge.handler
+
+    assert all(
+        bridge.handler in logging.getLogger(name).handlers
+        for name in bridge.logger_names
+    )
+    assert generator.llm.task_manager is task_manager
+    assert generator.researcher.task_id == "task-1"
+    assert generator.researcher.search_service.task_manager is task_manager
+    assert generator.writer.task_id == "task-1"
+
+    bridge.close()
+    bridge.close()
+
+    assert all(
+        handler not in logging.getLogger(name).handlers
+        for name in bridge.logger_names
+    )
+
+
+def test_facades_compose_the_extracted_components():
+    service = BlogService.__new__(BlogService)
+    service.generator = MagicMock()
+
+    assert isinstance(GenerationResultPipeline(service), GenerationResultPipeline)
+    assert isinstance(GraphExecutionRunner(service.generator), GraphExecutionRunner)
+
+
+def test_blog_generator_generate_delegates_to_execution_runner():
+    generator = BlogGenerator.__new__(BlogGenerator)
+    generator._execution_runner = MagicMock()
+    generator._execution_runner.generate.return_value = {"success": True}
+
+    result = generator.generate(
+        "Topic",
+        article_type="guide",
+        target_audience="advanced",
+        target_length="long",
+        source_material="Source",
+        on_progress=MagicMock(),
+    )
+
+    assert result == {"success": True}
+    generator._execution_runner.generate.assert_called_once_with(
+        topic="Topic",
+        article_type="guide",
+        target_audience="advanced",
+        target_length="long",
+        source_material="Source",
+        on_progress=generator._execution_runner.generate.call_args.kwargs["on_progress"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_blog_generator_generate_stream_delegates_to_execution_runner():
+    generator = BlogGenerator.__new__(BlogGenerator)
+
+    async def events(**kwargs):
+        assert kwargs == {
+            "topic": "Topic",
+            "article_type": "guide",
+            "target_audience": "advanced",
+            "target_length": "long",
+            "source_material": "Source",
+        }
+        yield {"stage": "writer", "state": {}}
+
+    generator._execution_runner = SimpleNamespace(generate_stream=events)
+
+    result = [
+        event
+        async for event in generator.generate_stream(
+            "Topic", "guide", "advanced", "long", "Source"
+        )
+    ]
+
+    assert result == [{"stage": "writer", "state": {}}]
+
+
+def test_result_pipeline_uses_facade_hooks_and_persists_before_completion():
+    service = MagicMock()
+    service._validate_final_state.return_value = "# Body"
+    service._generate_cover_image.return_value = (
+        "https://example.com/cover.png",
+        "/tmp/cover.png",
+        "Summary",
+    )
+    service._save_markdown.return_value = "/tmp/article.md"
+    service._generate_cover_video.return_value = "/tmp/cover.mp4"
+    service.generator = SimpleNamespace(llm=MagicMock(), _memory_storage=None)
+    task_manager = MagicMock()
+    db_service = MagicMock()
+    manager = MagicMock()
+    manager.attach_mock(db_service.save_history, "save_history")
+    manager.attach_mock(service._send_completion_event, "send_completion")
+    final_state = {
+        "final_markdown": "# Body",
+        "outline": {"title": "Title"},
+        "sections": [{}],
+        "images": [],
+        "code_blocks": [],
+        "search_results": [
+            {"url": "https://example.com/source", "title": "Source"}
+        ],
+    }
+    request = GenerationResultRequest(
+        task_id="task-1",
+        topic="Topic",
+        article_type="tutorial",
+        target_length="short",
+        final_state=final_state,
+        article_config={"sections_count": 1, "target_word_count": 1000},
+        generate_images=True,
+        generate_cover_video=True,
+        video_aspect_ratio="16:9",
+        task_manager=task_manager,
+    )
+
+    with patch(
+        "services.database_service.get_db_service", return_value=db_service
+    ):
+        result = GenerationResultPipeline(service).finalize(request)
+
+    assert result.saved_path == "/tmp/article.md"
+    assert result.cover_video_path == "/tmp/cover.mp4"
+    assert result.citations == [
+        {
+            "url": "https://example.com/source",
+            "title": "Source",
+            "domain": "example.com",
+            "snippet": "",
+        }
+    ]
+    assert [call[0] for call in manager.mock_calls[:2]] == [
+        "save_history",
+        "send_completion",
+    ]
+    service._generate_cover_image.assert_called_once()
+    service._save_markdown.assert_called_once()
+    service._generate_cover_video.assert_called_once()
+
+
+def test_run_generation_uses_task_event_bridge_for_setup_and_cleanup():
+    service = BlogService.__new__(BlogService)
+    snapshot = SimpleNamespace(
+        next=(),
+        tasks=(),
+        values={"error": "provider unavailable", "final_markdown": ""},
+    )
+    app = MagicMock()
+    app.stream.return_value = []
+    app.get_state.return_value = snapshot
+    service.generator = SimpleNamespace(app=app, llm=MagicMock())
+    service._interrupted_tasks = {}
+    task_manager = MagicMock()
+    bridge = MagicMock()
+    bridge.handler = None
+    bridge.logger_names = ()
+
+    with (
+        patch.dict(
+            "os.environ",
+            {"TOKEN_TRACKING_ENABLED": "false", "BLOG_TASK_LOG_ENABLED": "false"},
+        ),
+        patch("time.sleep"),
+        patch("logging_config.create_task_logger", return_value=None),
+        patch(
+            "services.blog_generator.blog_service.TaskEventBridge",
+            return_value=bridge,
+        ) as bridge_class,
+        patch("services.blog_generator.blog_service.update_queue_status"),
+    ):
+        service._run_generation(
+            task_id="task-1",
+            topic="topic",
+            article_type="tutorial",
+            target_audience="developers",
+            audience_adaptation="default",
+            target_length="short",
+            source_material="",
+            generate_images=False,
+            task_manager=task_manager,
+        )
+
+    bridge_class.assert_called_once_with(service.generator, task_manager, "task-1")
+    bridge.attach.assert_called_once_with()
+    bridge.inject_dependencies.assert_called_once_with()
+    bridge.close.assert_called_once_with()

--- a/backend/tests/verify_102_features.py
+++ b/backend/tests/verify_102_features.py
@@ -444,9 +444,11 @@ def benefit_full_integration():
     """验证所有 102 特性已集成到 BlogGenerator 主流程"""
     import inspect
     from services.blog_generator.generator import BlogGenerator
+    from services.blog_generator.orchestrator.graph_builder import GraphBuilder
 
     init_src = inspect.getsource(BlogGenerator.__init__)
-    workflow_src = inspect.getsource(BlogGenerator._build_workflow)
+    workflow_src = inspect.getsource(GraphBuilder.build)
+    add_node_src = inspect.getsource(BlogGenerator._add_node)
     planner_src = inspect.getsource(BlogGenerator._planner_node)
     writer_src = inspect.getsource(BlogGenerator._writer_node)
 
@@ -485,18 +487,22 @@ def benefit_full_integration():
     )
     call_chain["researcher → ToolRegistry (102.08)"] = "_tool_registry" in researcher_src
 
-    wrap_count = workflow_src.count("pipeline.wrap_node")
-    node_count = workflow_src.count("add_node")
+    wraps_contract = (
+        "generator._add_node" in workflow_src
+        and "for node_name, handler in nodes" in workflow_src
+        and "pipeline.wrap_node" in add_node_src
+        and "wrap_node_state_contract" in add_node_src
+    )
 
     lines = []
     for name, ok in components.items():
         lines.append(f"  {'✓' if ok else '✗'} {name}")
-    lines.append(f"节点包装: {wrap_count}/{node_count} 个节点通过 wrap_node 统一管理")
+    lines.append(f"统一节点注册边界: {'✓' if wraps_contract else '✗'}")
     lines.append("")
     lines.append("主流程调用链:")
     for name, ok in call_chain.items():
         lines.append(f"  {'✓' if ok else '✗'} {name}")
-    all_ok = all(components.values()) and all(call_chain.values())
+    all_ok = all(components.values()) and all(call_chain.values()) and wraps_contract
     assert all_ok, f"部分组件未集成: {[k for k, v in {**components, **call_chain}.items() if not v]}"
     lines.append("收益: 所有 102 特性已接入主流程，不再是孤岛代码")
     return "\n".join(lines)


### PR DESCRIPTION
## Summary
- extract task-scoped SSE logging and dependency wiring into `TaskEventBridge`
- centralize initial and resumed result persistence/completion in `GenerationResultPipeline`
- move LangGraph topology construction and compiled execution into `GraphBuilder` and `GraphExecutionRunner` while preserving public facades
- add signature, topology, delegation, lifecycle, and dependency-boundary regression contracts

Part of #159.

## Compatibility
- preserves `BlogService` and `BlogGenerator` public method signatures
- preserves LangGraph node names, edges, conditional route maps, SSE event shapes, result payloads, and failure semantics
- keeps the existing facade methods as compatibility entry points

## Verification
- `python -m pytest tests/ -q` (backend): 1438 passed, 12 skipped
- `npm test -- --run`: 447 passed
- `npm run build`: passed
- `PYTHONPATH=. python tests/verify_102_features.py`: 12/12 passed
- affected Playwright E2E excluding external-LLM completion: 8 passed (button state, progress/SSE, cancel, history, quality dialog, missing-blog API)
- live TC02 generation was attempted; the configured external model endpoint did not return from the first Planner request after the 600s test budget, so the task was cancelled. No application exception or orchestration failure was observed before cancellation.

## Review
- independent review found no production behavior regression
- review feedback strengthened topology expectations and handler-leak assertions before commit