### PR TITLE
refactor: extract generation nodes into module-level functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@ All notable changes to the Vibe Blog project will be documented in this file.
 
 ### Changed
 - ♻️ **媒体生成边界** — 将封面图、封面视频、序列视频和视频合并逻辑迁移为显式依赖的模块级函数，移除 `BlogService` 的媒体私有方法并保持降级与 SSE 契约。
+- ♻️ **生成节点函数边界** — 将 21 个 LangGraph 节点迁移为按阶段组织、显式依赖绑定的模块级函数，并让 `GraphBuilder` 通过 handler mapping 建图。
 
 ### Tests
 - ✨ **媒体 Pipeline 契约** — 覆盖依赖边界、摘要回退、横竖屏、单图与序列分支、事件载荷、顺序保持、合并失败及媒体降级完成流程。
+- ✨ **节点编排回归契约** — 覆盖节点依赖边界、图拓扑、运行时绑定、异步配图资源释放、状态合并及 research/writing/review/finalization 行为。
 
 ## 2026-08-01
 

--- a/backend/services/blog_generator/blog_service.py
+++ b/backend/services/blog_generator/blog_service.py
@@ -683,10 +683,10 @@ class BlogService:
                         'accumulated': accumulated
                     })
             
-            self.generator._outline_stream_callback = on_outline_stream
-            
-            # 101.113: 设置交互式标志，让 _planner_node 使用 interrupt()
-            self.generator._interactive = interactive
+            self.generator._configure_planner_runtime(
+                on_stream=on_outline_stream,
+                interactive=interactive,
+            )
             
             config = {"configurable": {"thread_id": f"blog_{task_id}"}}
             
@@ -735,8 +735,8 @@ class BlogService:
             from .style_profile import StyleProfile
             from .parallel import ParallelTaskExecutor
             style = StyleProfile.from_target_length(target_length)
-            self.generator.executor = ParallelTaskExecutor(
-                enable_parallel=style.enable_parallel,
+            self.generator._configure_execution_runtime(
+                ParallelTaskExecutor(enable_parallel=style.enable_parallel)
             )
 
             # 使用 stream 获取中间状态

--- a/backend/services/blog_generator/generator.py
+++ b/backend/services/blog_generator/generator.py
@@ -2,20 +2,18 @@
 长文博客生成器 - LangGraph 工作流主入口
 """
 
-import copy
 import logging
 import os
-import threading
 import uuid
 from concurrent.futures import ThreadPoolExecutor
+from functools import partial
 from typing import Dict, Any, Optional, Literal, Callable
 
 from langgraph.graph import StateGraph
 from langgraph.checkpoint.memory import MemorySaver
 from langgraph.types import interrupt
 
-from .schemas.state import SharedState, create_initial_state
-from .schemas.state_contracts import wrap_node_state_contract
+from .schemas.state import SharedState
 from .style_profile import StyleProfile
 from .agents.researcher import ResearcherAgent
 from .agents.planner import PlannerAgent
@@ -44,29 +42,42 @@ from .llm_proxy import TieredLLMProxy
 from .llm_tier_config import get_agent_tier
 from .orchestrator.execution_runner import GraphExecutionRunner
 from .orchestrator.graph_builder import GraphBuilder
-import uuid
+from .orchestrator.image_task_registry import ImageTaskRegistry
+from .orchestrator.nodes.finalization import (
+    assembler_node,
+    coder_and_artist_node,
+    factcheck_node,
+    humanizer_node,
+    summary_generator_node,
+    text_cleanup_node,
+    wait_for_images_node,
+)
+from .orchestrator.nodes.research import (
+    check_knowledge_node,
+    enhance_with_knowledge_node,
+    planner_node,
+    refine_search_node,
+    researcher_node,
+)
+from .orchestrator.nodes.review import (
+    consistency_check_node,
+    cross_section_dedup_node,
+    reviewer_node,
+    revision_node,
+)
+from .orchestrator.nodes.writing import (
+    deepen_content_node,
+    questioner_node,
+    section_evaluate_node,
+    section_improve_node,
+    writer_node,
+)
+from .cross_section_dedup import CrossSectionDeduplicator
+from .image_preplanner import ImagePreplanner
+from .prompts import get_prompt_manager
+from utils.text_cleanup import apply_full_cleanup
 
 logger = logging.getLogger(__name__)
-
-
-def _get_content_word_count(state: Dict[str, Any]) -> int:
-    """计算当前 state 中所有章节内容的总字数"""
-    sections = state.get('sections', [])
-    total = 0
-    for section in sections:
-        content = section.get('content', '')
-        if content:
-            total += len(content)
-    return total
-
-
-def _log_word_count_diff(agent_name: str, before: int, after: int):
-    """记录字数变化的 diff"""
-    diff = after - before
-    if diff >= 0:
-        logger.info(f"📊 [{agent_name}] 字数变化: {before} → {after} (+{diff} 字)")
-    else:
-        logger.info(f"📊 [{agent_name}] 字数变化: {before} → {after} ({diff} 字)")
 
 
 class BlogGenerator:
@@ -137,10 +148,8 @@ class BlogGenerator:
         self.tracker = SessionTracker()
         self.summary_generator = SummaryGeneratorAgent(_proxy('summary_generator')) if self._env_summary else None
 
-        # 配图异步任务字典：避免把 Future 对象放入 LangGraph state 导致 msgpack 序列化失败
-        # key = 随机字符串（存在 state['_image_task_id']），value = (Future, ThreadPoolExecutor)
-        self._image_tasks: dict = {}
-        self._image_tasks_lock = threading.Lock()
+        # Future stays outside SharedState so checkpoint serialization remains stable.
+        self._image_task_registry = ImageTaskRegistry()
 
         # 37.12 分层架构校验器（可选）
         self._layer_validator = None
@@ -202,17 +211,6 @@ class BlogGenerator:
         self.app = None
         self._execution_runner = GraphExecutionRunner(self)
 
-    def _validate_layer(self, layer_name: str, state: Dict[str, Any]):
-        """37.12 层间数据契约校验（仅日志警告，不阻断流程）"""
-        if not self._layer_validator:
-            return
-        try:
-            ok, missing = self._layer_validator.validate_inputs(layer_name, state)
-            if not ok:
-                logger.warning(f"🏗️ [{layer_name}] 层输入缺失: {missing}")
-        except Exception as e:
-            logger.debug(f"层校验异常: {e}")
-    
     def _build_workflow(self) -> StateGraph:
         """
         构建 LangGraph 工作流
@@ -220,360 +218,168 @@ class BlogGenerator:
         Returns:
             StateGraph 实例
         """
-        return GraphBuilder(self).build()
+        self._node_handlers = self._bind_node_handlers()
+        return GraphBuilder(
+            node_handlers=self._node_handlers,
+            routing_handlers=self._bind_routing_handlers(),
+            middleware_pipeline=self.pipeline,
+        ).build()
 
-    def _add_node(self, workflow: StateGraph, node_name: str, handler: Callable) -> None:
-        """Register middleware inside the stable state contract boundary."""
-        middleware_wrapped = self.pipeline.wrap_node(node_name, handler)
-        workflow.add_node(
-            node_name,
-            wrap_node_state_contract(node_name, middleware_wrapped),
-        )
+    def _bind_node_handlers(self):
+        return {
+            "researcher": partial(
+                researcher_node,
+                researcher=self.researcher,
+                layer_validator=self._layer_validator,
+            ),
+            "planner": partial(
+                planner_node,
+                planner=self.planner,
+                layer_validator=self._layer_validator,
+                on_stream=None,
+                interactive=False,
+                writing_skill_manager=self._writing_skill_manager,
+                llm_client=self.llm,
+                interrupt_fn=interrupt,
+                getenv=os.getenv,
+                image_preplanner_factory=ImagePreplanner,
+            ),
+            "writer": partial(
+                writer_node,
+                writer=self.writer,
+                layer_validator=self._layer_validator,
+                memory_storage=self._memory_storage,
+                configured_style=self.style,
+            ),
+            "check_knowledge": partial(
+                check_knowledge_node,
+                search_coordinator=self.search_coordinator,
+            ),
+            "refine_search": partial(
+                refine_search_node,
+                search_coordinator=self.search_coordinator,
+            ),
+            "enhance_with_knowledge": partial(
+                enhance_with_knowledge_node,
+                writer=self.writer,
+                parallel_executor=self.executor,
+                prompt_manager_factory=get_prompt_manager,
+                task_config_factory=TaskConfig,
+            ),
+            "questioner": partial(questioner_node, questioner=self.questioner),
+            "deepen_content": partial(
+                deepen_content_node,
+                writer=self.writer,
+                parallel_executor=self.executor,
+                tracker=self.tracker,
+                task_config_factory=TaskConfig,
+            ),
+            "section_evaluate": partial(
+                section_evaluate_node,
+                questioner=self.questioner,
+                tracker=self.tracker,
+                configured_style=self.style,
+            ),
+            "section_improve": partial(
+                section_improve_node,
+                writer=self.writer,
+                tracker=self.tracker,
+            ),
+            "coder_and_artist": partial(
+                coder_and_artist_node,
+                coder=self.coder,
+                artist=self.artist,
+                image_task_registry=self._image_task_registry,
+                executor_factory=ThreadPoolExecutor,
+                uuid_factory=lambda: str(uuid.uuid4()),
+            ),
+            "cross_section_dedup": partial(
+                cross_section_dedup_node,
+                getenv=os.getenv,
+                deduplicator_factory=CrossSectionDeduplicator,
+                llm_client=self.llm,
+            ),
+            "consistency_check": partial(
+                consistency_check_node,
+                configured_style=self.style,
+                env_thread_check=self._env_thread_check,
+                env_voice_check=self._env_voice_check,
+                thread_checker=self.thread_checker,
+                voice_checker=self.voice_checker,
+                parallel_executor=self.executor,
+                task_config_factory=TaskConfig,
+            ),
+            "reviewer": partial(
+                reviewer_node,
+                reviewer=self.reviewer,
+                tracker=self.tracker,
+                configured_style=self.style,
+            ),
+            "revision": partial(
+                revision_node,
+                writer=self.writer,
+                parallel_executor=self.executor,
+                configured_style=self.style,
+                task_config_factory=TaskConfig,
+            ),
+            "factcheck": partial(
+                factcheck_node,
+                factcheck=self.factcheck,
+                configured_style=self.style,
+                env_factcheck=self._env_factcheck,
+            ),
+            "text_cleanup": partial(
+                text_cleanup_node,
+                cleanup=apply_full_cleanup,
+                configured_style=self.style,
+                env_text_cleanup=self._env_text_cleanup,
+            ),
+            "humanizer": partial(
+                humanizer_node,
+                humanizer=self.humanizer,
+                configured_style=self.style,
+                env_humanizer=self._env_humanizer,
+            ),
+            "wait_for_images": partial(
+                wait_for_images_node,
+                image_task_registry=self._image_task_registry,
+                tracker=self.tracker,
+                timeout=600,
+            ),
+            "assembler": partial(assembler_node, assembler=self.assembler),
+            "summary_generator": partial(
+                summary_generator_node,
+                summary_generator=self.summary_generator,
+                configured_style=self.style,
+                env_summary=self._env_summary,
+            ),
+        }
+
+    def _bind_routing_handlers(self):
+        return {
+            "should_check_knowledge": self._should_check_knowledge,
+            "should_refine_search": self._should_refine_search,
+            "should_deepen": self._should_deepen,
+            "should_continue_questioning": self._should_continue_questioning,
+            "should_improve_sections": self._should_improve_sections,
+            "should_revise": self._should_revise,
+        }
+
+    def _configure_planner_runtime(self, *, on_stream, interactive):
+        planner_handler = self._node_handlers["planner"]
+        planner_handler.keywords["on_stream"] = on_stream
+        planner_handler.keywords["interactive"] = interactive
+
+    def _configure_execution_runtime(self, executor):
+        self.executor = executor
+        for node_name in (
+            "enhance_with_knowledge",
+            "deepen_content",
+            "consistency_check",
+            "revision",
+        ):
+            self._node_handlers[node_name].keywords["parallel_executor"] = executor
     
-    def _researcher_node(self, state: SharedState) -> SharedState:
-        """素材收集节点"""
-        if state.get('skip_researcher'):
-            logger.info("=== Step 1: 素材收集（已跳过） ===")
-            empty_defaults = {
-                'background_knowledge': '',
-                'key_concepts': [],
-                'search_results': [],
-                'reference_links': [],
-                'knowledge_source_stats': {},
-                'instructional_analysis': {},
-                'learning_objectives': [],
-                'verbatim_data': [],
-                'distilled_sources': [],
-                'material_by_type': {},
-                'common_themes': [],
-                'contradictions': [],
-                'content_gaps': [],
-                'unique_angles': [],
-                'writing_recommendations': {},
-            }
-            for key, default in empty_defaults.items():
-                if state.get(key) is None:
-                    state[key] = default
-            return state
-        logger.info("=== Step 1: 素材收集 ===")
-        self._validate_layer("research", state)
-        return self.researcher.run(state)
-    
-    def _planner_node(self, state: SharedState) -> SharedState:
-        """大纲规划节点"""
-        logger.info("=== Step 2: 大纲规划 ===")
-        self._validate_layer("structure", state)
-        # 使用实例变量中的流式回调
-        on_stream = getattr(self, '_outline_stream_callback', None)
-        result = self.planner.run(state, on_stream=on_stream)
-
-        # 交互式模式：使用 LangGraph 原生 interrupt 暂停图执行
-        outline = result.get('outline') if isinstance(result, dict) else None
-
-        # mini 模式或环境变量指定时自动确认大纲，跳过人工 interrupt
-        auto_confirm = (
-            state.get('target_length') == 'mini'
-            or os.getenv('OUTLINE_AUTO_CONFIRM', 'false').lower() == 'true'
-        )
-
-        if outline and getattr(self, '_interactive', False) and not auto_confirm:
-            sections = outline.get('sections', [])
-            interrupt_data = {
-                "type": "confirm_outline",
-                "title": outline.get("title", ""),
-                "sections": sections,
-                "sections_titles": [s.get("title", "") for s in sections],
-                "narrative_mode": outline.get("narrative_mode", ""),
-                "narrative_flow": outline.get("narrative_flow", {}),
-                "sections_narrative_roles": [s.get("narrative_role", "") for s in sections],
-            }
-            user_decision = interrupt(interrupt_data)
-
-            # 处理用户决策
-            if isinstance(user_decision, dict) and user_decision.get("action") == "edit":
-                edited_outline = user_decision.get("outline", outline)
-                logger.info(f"大纲已被用户修改: {edited_outline.get('title', '')}")
-                result['outline'] = edited_outline
-                result['sections'] = []  # 清空已有章节，重新写作
-            else:
-                logger.info("大纲已被用户确认")
-        elif outline and auto_confirm:
-            logger.info(f"[AutoConfirm] 自动确认大纲 (target_length={state.get('target_length')})")
-
-        # 102.06: 匹配写作技能，注入到 state 供 writer 使用
-        if self._writing_skill_manager:
-            try:
-                topic = state.get('topic', '')
-                article_type = state.get('article_type', '')
-                skill = self._writing_skill_manager.match_skill(topic, article_type)
-                if skill:
-                    result['_writing_skill_prompt'] = self._writing_skill_manager.build_system_prompt_section(skill)
-                    logger.info(f"匹配写作技能: {skill.name}")
-            except Exception as e:
-                logger.debug(f"写作技能匹配跳过: {e}")
-
-        # 41.05 图片预规划：在大纲确认后、写作前生成全局图片计划
-        if os.environ.get('IMAGE_PREPLAN_ENABLED', 'false').lower() == 'true':
-            try:
-                from .image_preplanner import ImagePreplanner
-                preplanner = ImagePreplanner(self.llm)
-                outline = result.get('outline', {})
-                image_plan = preplanner.plan(
-                    outline=outline,
-                    background_knowledge=state.get('background_knowledge', ''),
-                    article_type=state.get('article_type', 'tutorial'),
-                )
-                result['image_preplan'] = image_plan
-                logger.info(f"[41.05] 图片预规划完成: {len(image_plan)} 张")
-            except Exception as e:
-                logger.warning(f"[41.05] 图片预规划失败: {e}")
-
-        return result
-    
-    def _writer_node(self, state: SharedState) -> SharedState:
-        """内容撰写节点"""
-        logger.info("=== Step 3: 内容撰写 ===")
-        self._validate_layer("content", state)
-
-        # 102.03: 注入用户记忆到 background_knowledge
-        if self._memory_storage:
-            try:
-                user_id = state.get('user_id', 'default')
-                memory_injection = self._memory_storage.format_for_injection(user_id)
-                if memory_injection:
-                    bg = state.get('background_knowledge', '')
-                    state['background_knowledge'] = bg + "\n\n" + memory_injection if bg else memory_injection
-                    logger.info(f"注入用户记忆: {len(memory_injection)} 字符")
-            except Exception as e:
-                logger.debug(f"用户记忆注入跳过: {e}")
-
-        # 41.10: 注入人设 Prompt 到 state（供 Writer 使用）
-        style = self._get_style(state)
-        persona_prompt = style.get_persona_prompt()
-        if persona_prompt:
-            state['_persona_prompt'] = persona_prompt
-            logger.info(f"[41.10] 注入人设 Prompt: {persona_prompt[:60]}...")
-
-        before_count = _get_content_word_count(state)
-        result = self.writer.run(state)
-        after_count = _get_content_word_count(result)
-        _log_word_count_diff("Writer", before_count, after_count)
-        # 初始化累积知识（首次写作后）
-        if not result.get('accumulated_knowledge'):
-            result['accumulated_knowledge'] = result.get('background_knowledge', '')
-        return result
-    
-    def _check_knowledge_node(self, state: SharedState) -> SharedState:
-        """知识空白检查节点"""
-        search_count = state.get('search_count', 0)
-        max_count = state.get('max_search_count', 5)
-        logger.info(f"=== Step 3.5: 知识空白检查 (搜索次数: {search_count}/{max_count}) ===")
-        return self.search_coordinator.run(state)
-    
-    def _refine_search_node(self, state: SharedState) -> SharedState:
-        """细化搜索节点"""
-        search_count = state.get('search_count', 0) + 1
-        max_count = state.get('max_search_count', 5)
-        logger.info(f"=== Step 3.6: 细化搜索 (第 {search_count} 轮) ===")
-        
-        gaps = state.get('knowledge_gaps', [])
-        result = self.search_coordinator.refine_search(gaps, state)
-        
-        if result.get('success'):
-            logger.info(f"细化搜索完成: 获取 {len(result.get('results', []))} 条结果")
-        else:
-            logger.warning(f"细化搜索失败: {result.get('reason', '未知原因')}")
-        
-        return state
-    
-    def _enhance_with_knowledge_node(self, state: SharedState) -> SharedState:
-        """基于新知识增强内容节点（102.01 迁移：使用 ParallelTaskExecutor）"""
-        logger.info("=== Step 3.7: 知识增强 ===")
-
-        sections = state.get('sections', [])
-        gaps = state.get('knowledge_gaps', [])
-        new_knowledge = state.get('accumulated_knowledge', '')
-
-        if not gaps or not new_knowledge:
-            logger.info("没有需要增强的内容")
-            return state
-
-        from .prompts import get_prompt_manager
-        pm = get_prompt_manager()
-
-        # 收集需要增强的任务
-        enhance_items = []
-        for section in sections:
-            section_gaps = [g for g in gaps if not g.get('section_id') or g.get('section_id') == section.get('id')]
-            if section_gaps:
-                enhance_items.append((section, section_gaps))
-
-        if not enhance_items:
-            logger.info("没有需要增强的章节")
-            state['knowledge_gaps'] = []
-            return state
-
-        def enhance_single(section, section_gaps):
-            prompt = pm.render_writer_enhance_with_knowledge(
-                original_content=section.get('content', ''),
-                new_knowledge=new_knowledge,
-                knowledge_gaps=section_gaps,
-            )
-            return self.writer.llm.chat(messages=[{"role": "user", "content": prompt}])
-
-        tasks = [
-            {
-                "name": f"增强-{section.get('title', '')}",
-                "fn": enhance_single,
-                "args": (section, section_gaps),
-            }
-            for section, section_gaps in enhance_items
-        ]
-
-        results = self.executor.run_parallel(tasks, config=TaskConfig(
-            name="knowledge_enhance", timeout_seconds=120,
-        ))
-
-        for i, r in enumerate(results):
-            if r.success:
-                enhance_items[i][0]['content'] = r.result
-                logger.info(f"章节增强完成: {enhance_items[i][0].get('title', '')}")
-            else:
-                logger.error(f"章节增强失败: {r.error}")
-
-        enhanced_count = sum(1 for r in results if r.success)
-        logger.info(f"知识增强完成: {enhanced_count} 个章节")
-        state['knowledge_gaps'] = []
-        return state
-    
-    
-    
-    def _questioner_node(self, state: SharedState) -> SharedState:
-        """追问检查节点"""
-        logger.info("=== Step 4: 追问检查 ===")
-        return self.questioner.run(state)
-    
-    def _deepen_content_node(self, state: SharedState) -> SharedState:
-        """内容深化节点（102.01 迁移：使用 ParallelTaskExecutor）"""
-        logger.info("=== Step 4.1: 内容深化 ===")
-        before_count = _get_content_word_count(state)
-        state['questioning_count'] = state.get('questioning_count', 0) + 1
-
-        sections_to_deepen = [
-            r for r in state.get('question_results', [])
-            if not r.get('is_detailed_enough', True)
-        ]
-        total_to_deepen = len(sections_to_deepen)
-
-        if total_to_deepen == 0:
-            logger.info("没有需要深化的章节")
-            return state
-
-        # 构建任务列表
-        tasks = []
-        for idx, result in enumerate(sections_to_deepen, 1):
-            section_id = result.get('section_id', '')
-            vague_points = result.get('vague_points', [])
-
-            for section in state.get('sections', []):
-                if section.get('id') == section_id:
-                    section_title = section.get('title', section_id)
-                    progress_info = f"[{idx}/{total_to_deepen}]"
-                    tasks.append({
-                        "name": f"深化-{section_title}",
-                        "fn": self.writer.enhance_section,
-                        "kwargs": {
-                            "original_content": section.get('content', ''),
-                            "vague_points": vague_points,
-                            "section_title": section_title,
-                            "progress_info": progress_info,
-                        },
-                        "_section_id": section_id,
-                    })
-                    break
-
-        results = self.executor.run_parallel(tasks, config=TaskConfig(
-            name="content_deepen", timeout_seconds=120,
-        ))
-
-        # 回写结果
-        for i, r in enumerate(results):
-            if r.success:
-                target_id = tasks[i]["_section_id"]
-                for section in state.get('sections', []):
-                    if section.get('id') == target_id:
-                        section['content'] = r.result
-                        logger.info(f"章节深化完成: {section.get('title', '')}")
-                        break
-            else:
-                logger.error(f"章节深化失败: {r.error}")
-
-        after_count = _get_content_word_count(state)
-        _log_word_count_diff("内容深化", before_count, after_count)
-
-        # 69.05: 记录深化迭代快照
-        self.tracker.log_deepen_snapshot(
-            round_num=state.get('questioning_count', 0),
-            sections_deepened=total_to_deepen,
-            chars_added=after_count - before_count,
-        )
-
-        return state
-
-    # ========== 段落级 Generator-Critic Loop (#69.04) ==========
-
-    def _section_evaluate_node(self, state: SharedState) -> SharedState:
-        """段落多维度评估节点（Critic 角色）"""
-        # 双开关：环境变量 + StyleProfile
-        style = self._get_style(state)
-        if not self._is_enabled("SECTION_EVAL_ENABLED", getattr(style, "enable_thread_check", True)):
-            logger.info("段落评估已禁用，跳过")
-            state["section_evaluations"] = []
-            state["needs_section_improvement"] = False
-            return state
-
-        logger.info("=== Step 4.2: 段落多维度评估 ===")
-        sections = state.get("sections", [])
-        evaluations = []
-        needs_improvement = False
-
-        for i, section in enumerate(sections):
-            prev_summary = sections[i - 1].get("title", "") if i > 0 else ""
-            next_preview = sections[i + 1].get("title", "") if i < len(sections) - 1 else ""
-
-            evaluation = self.questioner.evaluate_section(
-                section_content=section.get("content", ""),
-                section_title=section.get("title", ""),
-                prev_summary=prev_summary,
-                next_preview=next_preview,
-            )
-            evaluation["section_idx"] = i
-            evaluations.append(evaluation)
-
-            if evaluation["overall_quality"] < 7.0:
-                needs_improvement = True
-                logger.info(
-                    f"  段落 [{section.get('title', '')}] 需改进: "
-                    f"overall={evaluation['overall_quality']}"
-                )
-
-        state["section_evaluations"] = evaluations
-        state["needs_section_improvement"] = needs_improvement
-
-        avg_score = (
-            sum(e["overall_quality"] for e in evaluations) / max(len(evaluations), 1)
-        )
-        logger.info(f"段落评估完成: 平均分 {avg_score:.1f}, 需改进={needs_improvement}")
-
-        # 69.05: 记录段落评估分数
-        for evaluation in evaluations:
-            self.tracker.log_section_evaluation(
-                section_title=sections[evaluation.get("section_idx", 0)].get("title", ""),
-                scores=evaluation.get("scores", {}),
-                overall=evaluation["overall_quality"],
-            )
-
-        return state
 
     def _should_improve_sections(self, state: SharedState) -> str:
         """判断是否需要段落级改进"""
@@ -598,341 +404,6 @@ class BlogGenerator:
         state["prev_section_avg_score"] = curr_avg
         return "improve"
 
-    def _section_improve_node(self, state: SharedState) -> SharedState:
-        """段落精准改进节点（Generator 角色）"""
-        logger.info("=== Step 4.3: 段落精准改进 ===")
-        evaluations = state.get("section_evaluations", [])
-        sections = state.get("sections", [])
-        improved_count = 0
-
-        for evaluation in evaluations:
-            idx = evaluation.get("section_idx", -1)
-            if evaluation["overall_quality"] >= 7.0 or idx < 0 or idx >= len(sections):
-                continue
-
-            section = sections[idx]
-            improved_content = self.writer.improve_section(
-                original_content=section.get("content", ""),
-                critique=evaluation,
-                section_title=section.get("title", ""),
-            )
-            section["content"] = improved_content
-            improved_count += 1
-
-        state["section_improve_count"] = state.get("section_improve_count", 0) + 1
-        logger.info(f"段落改进完成: 改进了 {improved_count} 个段落 (第 {state['section_improve_count']} 轮)")
-
-        # 69.05: 记录段落改进快照
-        new_avg = (
-            sum(e["overall_quality"] for e in evaluations) / max(len(evaluations), 1)
-        )
-        self.tracker.log_section_improve_snapshot(
-            round_num=state["section_improve_count"],
-            improved_count=improved_count,
-            avg_score_before=state.get("prev_section_avg_score", 0),
-            avg_score_after=new_avg,
-        )
-
-        return state
-    
-    def _coder_and_artist_node(self, state: SharedState) -> SharedState:
-        """代码生成（同步） + 配图生成（异步后台）
-
-        配图生成耗时长（~400s），但后续节点（dedup/reviewer/humanizer）不依赖图片。
-        因此将配图作为后台任务启动，在 assembler 前等待结果。
-        """
-        logger.info("=== Step 5: 代码生成 + 配图异步启动 ===")
-
-        # 1. 代码生成（同步，很快）
-        try:
-            state = self.coder.run(state)
-        except Exception as e:
-            logger.error(f"代码生成失败: {e}")
-
-        code_count = len(state.get('code_blocks', []))
-        logger.info(f"代码生成完成: {code_count} 个代码块")
-
-        # 2. 同步预处理章节，再将独立快照交给后台配图任务
-        state['sections'] = self.artist.preprocess_ascii_flowcharts(
-            state.get('sections', [])
-        )
-        artist_state = copy.deepcopy(state)
-        image_executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="artist")
-        future = image_executor.submit(self.artist.run, artist_state)
-
-        # 将 Future 存到实例字典，而非 state，避免 LangGraph msgpack 序列化失败
-        image_task_id = str(uuid.uuid4())
-        with self._image_tasks_lock:
-            self._image_tasks[image_task_id] = (future, image_executor)
-        state['_image_task_id'] = image_task_id
-        logger.info("配图生成已异步启动，不阻塞后续流程")
-
-        return state
-
-    def _wait_for_images_node(self, state: SharedState) -> SharedState:
-        """等待异步配图生成完成，合并结果到 state"""
-        image_task_id = state.pop('_image_task_id', None)
-        with self._image_tasks_lock:
-            future, executor = self._image_tasks.pop(image_task_id, (None, None)) \
-                if image_task_id else (None, None)
-
-        if future is None:
-            logger.warning("无配图异步任务，跳过等待")
-            return state
-
-        logger.info("=== 等待配图生成完成 ===")
-        try:
-            result = future.result(timeout=600)  # 最多等 10 分钟
-            if isinstance(result, dict):
-                if 'section_images' in result:
-                    state['section_images'] = result['section_images']
-                    logger.info(f"合并 section_images: {len(state['section_images'])} 张")
-                if 'images' in result:
-                    state['images'] = result['images']
-                self._merge_artist_image_ids(
-                    state.get('sections', []),
-                    result.get('sections', []),
-                )
-
-            image_count = len(state.get('images', []))
-            logger.info(f"=== 配图生成完成: {image_count} 张图片 ===")
-
-            # 69.05: 记录配图生成结果
-            for img in state.get('images', []):
-                self.tracker.log_image_generation(
-                    image_id=img.get('id', ''),
-                    image_type=img.get('render_method', ''),
-                    success=True,
-                )
-        except Exception as e:
-            logger.error(f"配图生成失败或超时: {e}")
-        finally:
-            if executor:
-                executor.shutdown(wait=False)
-
-        return state
-
-    @staticmethod
-    def _merge_artist_image_ids(current_sections, artist_sections) -> None:
-        """Merge only image associations, preserving newer section content."""
-        artist_by_id = {
-            section.get('id'): section
-            for section in artist_sections
-            if section.get('id')
-        }
-        for index, current in enumerate(current_sections):
-            artist_section = artist_by_id.get(current.get('id'))
-            if artist_section is None and index < len(artist_sections):
-                artist_section = artist_sections[index]
-            if not artist_section:
-                continue
-
-            image_ids = artist_section.get('image_ids', [])
-            if image_ids:
-                current['image_ids'] = list(dict.fromkeys(
-                    current.get('image_ids', []) + image_ids
-                ))
-    
-    def _reviewer_node(self, state: SharedState) -> SharedState:
-        """质量审核节点"""
-        logger.info("=== Step 7: 质量审核 ===")
-
-        # mini 模式：修订后跳过 R2 审核（revision_count 已达上限时，R2 结果不影响路由）
-        style = self._get_style(state)
-        revision_count = state.get('revision_count', 0)
-        if revision_count >= style.max_revision_rounds:
-            logger.info(f"[Reviewer] 已达最大修订轮数 ({style.max_revision_rounds})，跳过 R2 审核")
-            state['review_approved'] = True
-            return state
-
-        state = self.reviewer.run(state)
-
-        # 合并一致性检查发现的问题到 review_issues
-        consistency_issues = state.get('thread_issues', []) + state.get('voice_issues', [])
-        if consistency_issues:
-            existing = state.get('review_issues', [])
-            state['review_issues'] = existing + consistency_issues
-            logger.info(f"[Reviewer] 合并一致性检查问题: {len(consistency_issues)} 条")
-
-        # 69.05: 记录审核分数到 Langfuse
-        self.tracker.log_review_score(
-            score=state.get('review_score', 0),
-            round_num=state.get('revision_count', 0),
-            summary=f"issues={len(state.get('review_issues', []))} approved={state.get('review_approved', False)}",
-        )
-
-        return state
-    
-    def _revision_node(self, state: SharedState) -> SharedState:
-        """修订节点（102.01 迁移：使用 ParallelTaskExecutor）"""
-        logger.info("=== Step 7.1: 修订 ===")
-        before_count = _get_content_word_count(state)
-        state['revision_count'] = state.get('revision_count', 0) + 1
-
-        review_issues = state.get('review_issues', [])
-        total_issues = len(review_issues)
-        style = self._get_style(state)
-
-        if total_issues == 0:
-            logger.info("没有需要修订的问题")
-            return state
-
-        if style.revision_strategy == "correct_only":
-            self._revision_correct_only(state, review_issues)
-        else:
-            self._revision_enhance(state, review_issues)
-
-        after_count = _get_content_word_count(state)
-        _log_word_count_diff("修订", before_count, after_count)
-        return state
-
-    def _revision_correct_only(self, state, review_issues):
-        """correct_only 模式：按章节分组，使用 correct_section"""
-        section_issues = {}
-        for issue in review_issues:
-            section_id = issue.get('section_id', '')
-            if section_id not in section_issues:
-                section_issues[section_id] = []
-            section_issues[section_id].append({
-                'severity': issue.get('severity', 'medium'),
-                'description': issue.get('description', ''),
-                'affected_content': issue.get('affected_content', ''),
-            })
-
-        tasks = []
-        for idx, (section_id, issues) in enumerate(section_issues.items(), 1):
-            for section in state.get('sections', []):
-                if section.get('id') == section_id:
-                    section_title = section.get('title', section_id)
-                    progress_info = f"[{idx}/{len(section_issues)}]"
-                    tasks.append({
-                        "name": f"更正-{section_title}",
-                        "fn": self.writer.correct_section,
-                        "kwargs": {
-                            "original_content": section.get('content', ''),
-                            "issues": issues,
-                            "section_title": section_title,
-                            "progress_info": progress_info,
-                        },
-                        "_section_id": section_id,
-                    })
-                    break
-
-        results = self.executor.run_parallel(tasks, config=TaskConfig(
-            name="revision_correct", timeout_seconds=120,
-        ))
-
-        for i, r in enumerate(results):
-            if r.success:
-                target_id = tasks[i]["_section_id"]
-                for section in state.get('sections', []):
-                    if section.get('id') == target_id:
-                        section['content'] = r.result
-                        break
-            else:
-                logger.error(f"章节更正失败: {r.error}")
-
-    def _revision_enhance(self, state, review_issues):
-        """enhance 模式：按问题逐个修订"""
-        tasks = []
-        for idx, issue in enumerate(review_issues, 1):
-            section_id = issue.get('section_id', '')
-            suggestion = issue.get('suggestion', '')
-
-            for section in state.get('sections', []):
-                if section.get('id') == section_id:
-                    section_title = section.get('title', section_id)
-                    progress_info = f"[{idx}/{len(review_issues)}]"
-                    tasks.append({
-                        "name": f"修订-{section_title}",
-                        "fn": self.writer.enhance_section,
-                        "kwargs": {
-                            "original_content": section.get('content', ''),
-                            "vague_points": [{
-                                'location': section_title,
-                                'issue': issue.get('description', ''),
-                                'question': suggestion,
-                                'suggestion': '根据审核建议修改',
-                            }],
-                            "section_title": section_title,
-                            "progress_info": progress_info,
-                        },
-                        "_section_id": section_id,
-                    })
-                    break
-
-        results = self.executor.run_parallel(tasks, config=TaskConfig(
-            name="revision_enhance", timeout_seconds=240,
-        ))
-
-        for i, r in enumerate(results):
-            if r.success:
-                target_id = tasks[i]["_section_id"]
-                for section in state.get('sections', []):
-                    if section.get('id') == target_id:
-                        section['content'] = r.result
-                        break
-            else:
-                logger.error(f"章节修订失败: {r.error}")
-
-    def _cross_section_dedup_node(self, state: SharedState) -> SharedState:
-        """41.09 跨章节语义去重节点"""
-        if os.environ.get('CROSS_SECTION_DEDUP_ENABLED', 'false').lower() != 'true':
-            return state
-        sections = state.get('sections', [])
-        if len(sections) < 2:
-            return state
-        logger.info("=== Step 5.5: 跨章节语义去重 ===")
-        try:
-            from .cross_section_dedup import CrossSectionDeduplicator
-            dedup = CrossSectionDeduplicator(llm_client=self.llm)
-            state['sections'] = dedup.deduplicate(sections)
-        except Exception as e:
-            logger.warning(f"[Dedup] 异常，跳过去重: {e}")
-        return state
-
-    def _consistency_check_node(self, state: SharedState) -> SharedState:
-        """一致性检查节点（102.01 迁移：使用 ParallelTaskExecutor）"""
-        sections = state.get('sections', [])
-        if len(sections) < 2:
-            state['thread_issues'] = []
-            state['voice_issues'] = []
-            return state
-
-        style = self._get_style(state)
-        thread_enabled = self._is_enabled(self._env_thread_check, style.enable_thread_check)
-        voice_enabled = self._is_enabled(self._env_voice_check, style.enable_voice_check)
-
-        if not thread_enabled and not voice_enabled:
-            state['thread_issues'] = []
-            state['voice_issues'] = []
-            return state
-
-        logger.info("=== Step 6.5: 一致性检查（叙事 + 语气）===")
-
-        tasks = []
-        if thread_enabled:
-            tasks.append({"name": "叙事一致性", "fn": self.thread_checker.run, "args": (state,)})
-        if voice_enabled:
-            tasks.append({"name": "语气一致性", "fn": self.voice_checker.run, "args": (state,)})
-
-        results = self.executor.run_parallel(tasks, config=TaskConfig(
-            name="consistency_check", timeout_seconds=120,
-        ))
-
-        for r in results:
-            if not r.success:
-                logger.error(f"[ConsistencyCheck] {r.task_name} 异常: {r.error}")
-
-        if not thread_enabled:
-            state['thread_issues'] = []
-        if not voice_enabled:
-            state['voice_issues'] = []
-
-        thread_count = len(state.get('thread_issues', []))
-        voice_count = len(state.get('voice_issues', []))
-        logger.info(f"[ConsistencyCheck] 完成: 叙事问题 {thread_count}, 语气问题 {voice_count}")
-        return state
 
     def _get_style(self, state: SharedState) -> StyleProfile:
         """获取当前运行的 StyleProfile（实例级 > state 级 > target_length 推断）"""
@@ -957,81 +428,7 @@ class BlogGenerator:
             "recursion_limit": recursion_limit,
         }
 
-    def _is_enabled(self, env_flag: bool, style_flag: bool) -> bool:
-        """环境变量 AND StyleProfile 双重开关"""
-        return env_flag and style_flag
 
-    def _factcheck_node(self, state: SharedState) -> SharedState:
-        """事实核查节点"""
-        # mini 模式跳过事实核查（节省 ~280s）
-        target_length = state.get('target_length', 'medium')
-        if target_length == 'mini':
-            logger.info("[FactCheck] mini 模式，跳过事实核查")
-            return state
-        style = self._get_style(state)
-        if not self._is_enabled(self._env_factcheck, style.enable_fact_check):
-            logger.info("=== Step 7.3: 事实核查（已禁用，跳过）===")
-            return state
-        logger.info("=== Step 7.3: 事实核查 ===")
-        try:
-            return self.factcheck.run(state)
-        except Exception as e:
-            logger.error(f"[FactCheck] 异常，降级跳过: {e}")
-            return state
-
-    def _text_cleanup_node(self, state: SharedState) -> SharedState:
-        """确定性文本清理节点（纯正则，零 LLM）"""
-        style = self._get_style(state)
-        if not self._is_enabled(self._env_text_cleanup, style.enable_text_cleanup):
-            logger.info("=== Step 7.4: 文本清理（已禁用，跳过）===")
-            return state
-        logger.info("=== Step 7.4: 确定性文本清理 ===")
-        from utils.text_cleanup import apply_full_cleanup
-        total_fixes = 0
-        for section in state.get('sections', []):
-            content = section.get('content', '')
-            if not content:
-                continue
-            result = apply_full_cleanup(content)
-            section['content'] = result['text']
-            fixes = result['total_fixes']
-            if fixes:
-                logger.info(f"  [{section.get('title', '')}] 修复 {fixes} 处: {result['stats']}")
-                total_fixes += fixes
-        logger.info(f"[TextCleanup] 完成: 共修复 {total_fixes} 处")
-        return state
-
-    def _humanizer_node(self, state: SharedState) -> SharedState:
-        """去 AI 味节点"""
-        style = self._get_style(state)
-        if not self._is_enabled(self._env_humanizer, style.enable_humanizer):
-            logger.info("=== Step 7.5: 去 AI 味（已禁用，跳过）===")
-            return state
-        logger.info("=== Step 7.5: 去 AI 味 ===")
-        try:
-            return self.humanizer.run(state)
-        except Exception as e:
-            logger.error(f"[Humanizer] 异常，降级使用原始内容: {e}")
-            return state
-
-    def _summary_generator_node(self, state: SharedState) -> SharedState:
-        """博客导读 + SEO 关键词生成节点"""
-        style = self._get_style(state)
-        if not self._is_enabled(self._env_summary, style.enable_summary_gen):
-            logger.info("=== Step 9: 导读+SEO（已禁用，跳过）===")
-            return state
-        logger.info("=== Step 9: 导读 + SEO 关键词生成 ===")
-        try:
-            return self.summary_generator.run(state)
-        except Exception as e:
-            logger.error(f"[SummaryGenerator] 异常，降级跳过: {e}")
-            return state
-
-    def _assembler_node(self, state: SharedState) -> SharedState:
-        """文档组装节点"""
-        logger.info("=== Step 8: 文档组装 ===")
-        return self.assembler.run(state)
-    
     def _should_deepen(self, state: SharedState) -> Literal["deepen", "continue"]:
         """判断是否需要深化内容 — 统一用 StyleProfile 控制"""
         count = state.get('questioning_count', 0)

--- a/backend/services/blog_generator/orchestrator/execution_runner.py
+++ b/backend/services/blog_generator/orchestrator/execution_runner.py
@@ -30,7 +30,9 @@ class GraphExecutionRunner:
             generator.compile()
 
         style = StyleProfile.from_target_length(target_length)
-        generator.executor = ParallelTaskExecutor(enable_parallel=style.enable_parallel)
+        generator._configure_execution_runtime(
+            ParallelTaskExecutor(enable_parallel=style.enable_parallel)
+        )
 
         token_tracker = None
         cost_tracker = None

--- a/backend/services/blog_generator/orchestrator/graph_builder.py
+++ b/backend/services/blog_generator/orchestrator/graph_builder.py
@@ -1,72 +1,105 @@
-"""LangGraph workflow construction."""
+"""LangGraph workflow construction from explicit handler mappings."""
 
 from langgraph.graph import END, START, StateGraph
 
 from ..schemas.state import SharedState
+from ..schemas.state_contracts import wrap_node_state_contract
+
+
+NODE_NAMES = (
+    "researcher",
+    "planner",
+    "writer",
+    "check_knowledge",
+    "refine_search",
+    "enhance_with_knowledge",
+    "questioner",
+    "deepen_content",
+    "coder_and_artist",
+    "cross_section_dedup",
+    "section_evaluate",
+    "section_improve",
+    "consistency_check",
+    "reviewer",
+    "revision",
+    "factcheck",
+    "text_cleanup",
+    "humanizer",
+    "wait_for_images",
+    "assembler",
+    "summary_generator",
+)
+
+ROUTING_NAMES = (
+    "should_check_knowledge",
+    "should_refine_search",
+    "should_deepen",
+    "should_continue_questioning",
+    "should_improve_sections",
+    "should_revise",
+)
 
 
 class GraphBuilder:
-    def __init__(self, generator):
-        self.generator = generator
+    def __init__(self, *, node_handlers, routing_handlers, middleware_pipeline):
+        self.node_handlers = dict(node_handlers)
+        self.routing_handlers = dict(routing_handlers)
+        self.middleware_pipeline = middleware_pipeline
+        self._validate_keys("node", self.node_handlers, NODE_NAMES)
+        self._validate_keys("routing", self.routing_handlers, ROUTING_NAMES)
+
+    @staticmethod
+    def _validate_keys(kind, handlers, expected):
+        expected_keys = set(expected)
+        actual_keys = set(handlers)
+        if actual_keys != expected_keys:
+            missing = sorted(expected_keys - actual_keys)
+            extra = sorted(actual_keys - expected_keys)
+            raise ValueError(
+                f"Invalid {kind} handler keys: missing={missing}, extra={extra}"
+            )
+
+    def _add_node(self, workflow, node_name, handler):
+        middleware_wrapped = self.middleware_pipeline.wrap_node(node_name, handler)
+        workflow.add_node(
+            node_name,
+            wrap_node_state_contract(node_name, middleware_wrapped),
+        )
 
     def build(self):
-        generator = self.generator
         workflow = StateGraph(SharedState)
+        for node_name in NODE_NAMES:
+            self._add_node(workflow, node_name, self.node_handlers[node_name])
 
-        nodes = (
-            ("researcher", generator._researcher_node),
-            ("planner", generator._planner_node),
-            ("writer", generator._writer_node),
-            ("check_knowledge", generator._check_knowledge_node),
-            ("refine_search", generator._refine_search_node),
-            ("enhance_with_knowledge", generator._enhance_with_knowledge_node),
-            ("questioner", generator._questioner_node),
-            ("deepen_content", generator._deepen_content_node),
-            ("coder_and_artist", generator._coder_and_artist_node),
-            ("cross_section_dedup", generator._cross_section_dedup_node),
-            ("section_evaluate", generator._section_evaluate_node),
-            ("section_improve", generator._section_improve_node),
-            ("consistency_check", generator._consistency_check_node),
-            ("reviewer", generator._reviewer_node),
-            ("revision", generator._revision_node),
-            ("factcheck", generator._factcheck_node),
-            ("text_cleanup", generator._text_cleanup_node),
-            ("humanizer", generator._humanizer_node),
-            ("wait_for_images", generator._wait_for_images_node),
-            ("assembler", generator._assembler_node),
-            ("summary_generator", generator._summary_generator_node),
-        )
-        for node_name, handler in nodes:
-            generator._add_node(workflow, node_name, handler)
-
+        routes = self.routing_handlers
         workflow.add_edge(START, "researcher")
         workflow.add_edge("researcher", "planner")
         workflow.add_edge("planner", "writer")
         workflow.add_conditional_edges(
             "writer",
-            generator._should_check_knowledge,
+            routes["should_check_knowledge"],
             {"check": "check_knowledge", "skip": "questioner"},
         )
         workflow.add_conditional_edges(
             "check_knowledge",
-            generator._should_refine_search,
+            routes["should_refine_search"],
             {"search": "refine_search", "continue": "questioner"},
         )
         workflow.add_edge("refine_search", "enhance_with_knowledge")
         workflow.add_edge("enhance_with_knowledge", "check_knowledge")
         workflow.add_conditional_edges(
             "questioner",
-            generator._should_deepen,
+            routes["should_deepen"],
             {"deepen": "deepen_content", "continue": "section_evaluate"},
         )
         workflow.add_conditional_edges(
             "deepen_content",
-            generator._should_continue_questioning,
+            routes["should_continue_questioning"],
             {"questioner": "questioner", "section_evaluate": "section_evaluate"},
         )
         workflow.add_conditional_edges(
             "section_evaluate",
-            generator._should_improve_sections,
+            routes["should_improve_sections"],
             {"improve": "section_improve", "continue": "coder_and_artist"},
         )
         workflow.add_edge("section_improve", "section_evaluate")
@@ -75,7 +108,7 @@ class GraphBuilder:
         workflow.add_edge("consistency_check", "reviewer")
         workflow.add_conditional_edges(
             "reviewer",
-            generator._should_revise,
+            routes["should_revise"],
             {"revision": "revision", "assemble": "factcheck"},
         )
         workflow.add_edge("revision", "reviewer")
@@ -85,5 +118,4 @@ class GraphBuilder:
         workflow.add_edge("wait_for_images", "assembler")
         workflow.add_edge("assembler", "summary_generator")
         workflow.add_edge("summary_generator", END)
-
         return workflow

--- a/backend/services/blog_generator/orchestrator/image_task_registry.py
+++ b/backend/services/blog_generator/orchestrator/image_task_registry.py
@@ -1,0 +1,39 @@
+"""Thread-safe ownership of detached artist tasks."""
+
+import threading
+
+
+class ImageTaskRegistry:
+    def __init__(self):
+        self._tasks = {}
+        self._lock = threading.Lock()
+
+    def register(self, task_id, future, executor) -> None:
+        with self._lock:
+            if task_id in self._tasks:
+                raise ValueError(f"Image task already registered: {task_id}")
+            self._tasks[task_id] = (future, executor)
+
+    def pop(self, task_id, *, timeout=None, default=None):
+        with self._lock:
+            task = self._tasks.pop(task_id, None)
+        if task is None:
+            return default
+        future, executor = task
+        try:
+            if timeout is None:
+                return future.result()
+            return future.result(timeout=timeout)
+        finally:
+            executor.shutdown(wait=False)
+
+    def discard(self, task_id) -> None:
+        with self._lock:
+            task = self._tasks.pop(task_id, None)
+        if task is None:
+            return
+        future, executor = task
+        try:
+            future.cancel()
+        finally:
+            executor.shutdown(wait=False)

--- a/backend/services/blog_generator/orchestrator/nodes/__init__.py
+++ b/backend/services/blog_generator/orchestrator/nodes/__init__.py
@@ -1,0 +1,29 @@
+"""Module-level LangGraph node handlers."""
+
+import logging
+
+from ...style_profile import StyleProfile
+
+
+logger = logging.getLogger("services.blog_generator.generator")
+
+
+def validate_layer(layer_validator, layer_name, state):
+    if not layer_validator:
+        return
+    try:
+        ok, missing = layer_validator.validate_inputs(layer_name, state)
+        if not ok:
+            logger.warning(f"🏗️ [{layer_name}] 层输入缺失: {missing}")
+    except Exception as error:
+        logger.debug(f"层校验异常: {error}")
+
+
+def resolve_style(state, configured_style):
+    if configured_style:
+        return configured_style
+    return StyleProfile.from_target_length(state.get("target_length", "medium"))
+
+
+def is_enabled(environment_flag, style_flag):
+    return environment_flag and style_flag

--- a/backend/services/blog_generator/orchestrator/nodes/finalization.py
+++ b/backend/services/blog_generator/orchestrator/nodes/finalization.py
@@ -1,0 +1,201 @@
+"""Code, image, cleanup, and assembly node handlers."""
+
+import copy
+import logging
+
+from . import is_enabled, resolve_style
+
+logger = logging.getLogger("services.blog_generator.generator")
+_MISSING_IMAGE_TASK = object()
+
+
+def coder_and_artist_node(
+    state,
+    *,
+    coder,
+    artist,
+    image_task_registry,
+    executor_factory,
+    uuid_factory,
+):
+    logger.info("=== Step 5: 代码生成 + 配图异步启动 ===")
+    try:
+        state = coder.run(state)
+    except Exception as error:
+        logger.error(f"代码生成失败: {error}")
+    logger.info(f"代码生成完成: {len(state.get('code_blocks', []))} 个代码块")
+
+    state["sections"] = artist.preprocess_ascii_flowcharts(
+        state.get("sections", [])
+    )
+    artist_state = copy.deepcopy(state)
+    image_executor = executor_factory(
+        max_workers=1, thread_name_prefix="artist"
+    )
+    future = image_executor.submit(artist.run, artist_state)
+    image_task_id = uuid_factory()
+    image_task_registry.register(image_task_id, future, image_executor)
+    state["_image_task_id"] = image_task_id
+    logger.info("配图生成已异步启动，不阻塞后续流程")
+    return state
+
+
+def wait_for_images_node(
+    state,
+    *,
+    image_task_registry,
+    tracker,
+    timeout,
+):
+    image_task_id = state.pop("_image_task_id", None)
+    if not image_task_id:
+        logger.warning("无配图异步任务，跳过等待")
+        return state
+    logger.info("=== 等待配图生成完成 ===")
+    try:
+        result = image_task_registry.pop(
+            image_task_id,
+            timeout=timeout,
+            default=_MISSING_IMAGE_TASK,
+        )
+        if result is _MISSING_IMAGE_TASK:
+            logger.warning("无配图异步任务，跳过等待")
+            return state
+        if isinstance(result, dict):
+            if "section_images" in result:
+                state["section_images"] = result["section_images"]
+                logger.info(
+                    f"合并 section_images: {len(state['section_images'])} 张"
+                )
+            if "images" in result:
+                state["images"] = result["images"]
+            merge_artist_image_ids(
+                state.get("sections", []), result.get("sections", [])
+            )
+        logger.info(f"=== 配图生成完成: {len(state.get('images', []))} 张图片 ===")
+        for image in state.get("images", []):
+            tracker.log_image_generation(
+                image_id=image.get("id", ""),
+                image_type=image.get("render_method", ""),
+                success=True,
+            )
+    except Exception as error:
+        logger.error(f"配图生成失败或超时: {error}")
+    return state
+
+
+def merge_artist_image_ids(current_sections, artist_sections):
+    artist_by_id = {
+        section.get("id"): section
+        for section in artist_sections
+        if section.get("id")
+    }
+    for index, current in enumerate(current_sections):
+        artist_section = artist_by_id.get(current.get("id"))
+        if artist_section is None and index < len(artist_sections):
+            artist_section = artist_sections[index]
+        if not artist_section:
+            continue
+        image_ids = artist_section.get("image_ids", [])
+        if image_ids:
+            current["image_ids"] = list(
+                dict.fromkeys(current.get("image_ids", []) + image_ids)
+            )
+
+
+def factcheck_node(
+    state,
+    *,
+    factcheck,
+    configured_style,
+    env_factcheck,
+):
+    if state.get("target_length", "medium") == "mini":
+        logger.info("[FactCheck] mini 模式，跳过事实核查")
+        return state
+    if not is_enabled(
+        env_factcheck, resolve_style(state, configured_style).enable_fact_check
+    ):
+        logger.info("=== Step 7.3: 事实核查（已禁用，跳过）===")
+        return state
+    logger.info("=== Step 7.3: 事实核查 ===")
+    try:
+        return factcheck.run(state)
+    except Exception as error:
+        logger.error(f"[FactCheck] 异常，降级跳过: {error}")
+        return state
+
+
+def text_cleanup_node(
+    state,
+    *,
+    cleanup,
+    configured_style,
+    env_text_cleanup,
+):
+    if not is_enabled(
+        env_text_cleanup, resolve_style(state, configured_style).enable_text_cleanup
+    ):
+        logger.info("=== Step 7.4: 文本清理（已禁用，跳过）===")
+        return state
+    logger.info("=== Step 7.4: 确定性文本清理 ===")
+    total_fixes = 0
+    for section in state.get("sections", []):
+        content = section.get("content", "")
+        if not content:
+            continue
+        result = cleanup(content)
+        section["content"] = result["text"]
+        fixes = result["total_fixes"]
+        if fixes:
+            logger.info(
+                f"  [{section.get('title', '')}] 修复 {fixes} 处: {result['stats']}"
+            )
+            total_fixes += fixes
+    logger.info(f"[TextCleanup] 完成: 共修复 {total_fixes} 处")
+    return state
+
+
+def humanizer_node(
+    state,
+    *,
+    humanizer,
+    configured_style,
+    env_humanizer,
+):
+    if not is_enabled(
+        env_humanizer, resolve_style(state, configured_style).enable_humanizer
+    ):
+        logger.info("=== Step 7.5: 去 AI 味（已禁用，跳过）===")
+        return state
+    logger.info("=== Step 7.5: 去 AI 味 ===")
+    try:
+        return humanizer.run(state)
+    except Exception as error:
+        logger.error(f"[Humanizer] 异常，降级使用原始内容: {error}")
+        return state
+
+
+def assembler_node(state, *, assembler):
+    logger.info("=== Step 8: 文档组装 ===")
+    return assembler.run(state)
+
+
+def summary_generator_node(
+    state,
+    *,
+    summary_generator,
+    configured_style,
+    env_summary,
+):
+    if not is_enabled(
+        env_summary, resolve_style(state, configured_style).enable_summary_gen
+    ):
+        logger.info("=== Step 9: 导读+SEO（已禁用，跳过）===")
+        return state
+    logger.info("=== Step 9: 导读 + SEO 关键词生成 ===")
+    try:
+        return summary_generator.run(state)
+    except Exception as error:
+        logger.error(f"[SummaryGenerator] 异常，降级跳过: {error}")
+        return state

--- a/backend/services/blog_generator/orchestrator/nodes/research.py
+++ b/backend/services/blog_generator/orchestrator/nodes/research.py
@@ -1,0 +1,197 @@
+"""Research and planning node handlers."""
+
+import logging
+
+from . import validate_layer
+
+logger = logging.getLogger("services.blog_generator.generator")
+
+
+def researcher_node(state, *, researcher, layer_validator):
+    if state.get("skip_researcher"):
+        logger.info("=== Step 1: 素材收集（已跳过） ===")
+        empty_defaults = {
+            "background_knowledge": "",
+            "key_concepts": [],
+            "search_results": [],
+            "reference_links": [],
+            "knowledge_source_stats": {},
+            "instructional_analysis": {},
+            "learning_objectives": [],
+            "verbatim_data": [],
+            "distilled_sources": [],
+            "material_by_type": {},
+            "common_themes": [],
+            "contradictions": [],
+            "content_gaps": [],
+            "unique_angles": [],
+            "writing_recommendations": {},
+        }
+        for key, default in empty_defaults.items():
+            if state.get(key) is None:
+                state[key] = default
+        return state
+    logger.info("=== Step 1: 素材收集 ===")
+    validate_layer(layer_validator, "research", state)
+    return researcher.run(state)
+
+
+def planner_node(
+    state,
+    *,
+    planner,
+    layer_validator,
+    on_stream,
+    interactive,
+    writing_skill_manager,
+    llm_client,
+    interrupt_fn,
+    getenv,
+    image_preplanner_factory,
+):
+    logger.info("=== Step 2: 大纲规划 ===")
+    validate_layer(layer_validator, "structure", state)
+    result = planner.run(state, on_stream=on_stream)
+    outline = result.get("outline") if isinstance(result, dict) else None
+    auto_confirm = (
+        state.get("target_length") == "mini"
+        or getenv("OUTLINE_AUTO_CONFIRM", "false").lower() == "true"
+    )
+
+    if outline and interactive and not auto_confirm:
+        sections = outline.get("sections", [])
+        user_decision = interrupt_fn({
+            "type": "confirm_outline",
+            "title": outline.get("title", ""),
+            "sections": sections,
+            "sections_titles": [section.get("title", "") for section in sections],
+            "narrative_mode": outline.get("narrative_mode", ""),
+            "narrative_flow": outline.get("narrative_flow", {}),
+            "sections_narrative_roles": [
+                section.get("narrative_role", "") for section in sections
+            ],
+        })
+        if isinstance(user_decision, dict) and user_decision.get("action") == "edit":
+            edited_outline = user_decision.get("outline", outline)
+            logger.info(f"大纲已被用户修改: {edited_outline.get('title', '')}")
+            result["outline"] = edited_outline
+            result["sections"] = []
+        else:
+            logger.info("大纲已被用户确认")
+    elif outline and auto_confirm:
+        logger.info(
+            f"[AutoConfirm] 自动确认大纲 (target_length={state.get('target_length')})"
+        )
+
+    if writing_skill_manager:
+        try:
+            skill = writing_skill_manager.match_skill(
+                state.get("topic", ""), state.get("article_type", "")
+            )
+            if skill:
+                result["_writing_skill_prompt"] = (
+                    writing_skill_manager.build_system_prompt_section(skill)
+                )
+                logger.info(f"匹配写作技能: {skill.name}")
+        except Exception as error:
+            logger.debug(f"写作技能匹配跳过: {error}")
+
+    if getenv("IMAGE_PREPLAN_ENABLED", "false").lower() == "true":
+        try:
+            preplanner = image_preplanner_factory(llm_client)
+            image_plan = preplanner.plan(
+                outline=result.get("outline", {}),
+                background_knowledge=state.get("background_knowledge", ""),
+                article_type=state.get("article_type", "tutorial"),
+            )
+            result["image_preplan"] = image_plan
+            logger.info(f"[41.05] 图片预规划完成: {len(image_plan)} 张")
+        except Exception as error:
+            logger.warning(f"[41.05] 图片预规划失败: {error}")
+    return result
+
+
+def check_knowledge_node(state, *, search_coordinator):
+    search_count = state.get("search_count", 0)
+    max_count = state.get("max_search_count", 5)
+    logger.info(
+        f"=== Step 3.5: 知识空白检查 (搜索次数: {search_count}/{max_count}) ==="
+    )
+    return search_coordinator.run(state)
+
+
+def refine_search_node(state, *, search_coordinator):
+    search_count = state.get("search_count", 0) + 1
+    logger.info(f"=== Step 3.6: 细化搜索 (第 {search_count} 轮) ===")
+    result = search_coordinator.refine_search(state.get("knowledge_gaps", []), state)
+    if result.get("success"):
+        logger.info(f"细化搜索完成: 获取 {len(result.get('results', []))} 条结果")
+    else:
+        logger.warning(f"细化搜索失败: {result.get('reason', '未知原因')}")
+    return state
+
+
+def enhance_with_knowledge_node(
+    state,
+    *,
+    writer,
+    parallel_executor,
+    prompt_manager_factory,
+    task_config_factory,
+):
+    logger.info("=== Step 3.7: 知识增强 ===")
+    sections = state.get("sections", [])
+    gaps = state.get("knowledge_gaps", [])
+    new_knowledge = state.get("accumulated_knowledge", "")
+    if not gaps or not new_knowledge:
+        logger.info("没有需要增强的内容")
+        return state
+
+    prompt_manager = prompt_manager_factory()
+    enhance_items = []
+    for section in sections:
+        section_gaps = [
+            gap
+            for gap in gaps
+            if not gap.get("section_id")
+            or gap.get("section_id") == section.get("id")
+        ]
+        if section_gaps:
+            enhance_items.append((section, section_gaps))
+    if not enhance_items:
+        logger.info("没有需要增强的章节")
+        state["knowledge_gaps"] = []
+        return state
+
+    def enhance_single(section, section_gaps):
+        prompt = prompt_manager.render_writer_enhance_with_knowledge(
+            original_content=section.get("content", ""),
+            new_knowledge=new_knowledge,
+            knowledge_gaps=section_gaps,
+        )
+        return writer.llm.chat(messages=[{"role": "user", "content": prompt}])
+
+    tasks = [
+        {
+            "name": f"增强-{section.get('title', '')}",
+            "fn": enhance_single,
+            "args": (section, section_gaps),
+        }
+        for section, section_gaps in enhance_items
+    ]
+    results = parallel_executor.run_parallel(
+        tasks,
+        config=task_config_factory(name="knowledge_enhance", timeout_seconds=120),
+    )
+    for index, result in enumerate(results):
+        if result.success:
+            enhance_items[index][0]["content"] = result.result
+            logger.info(
+                f"章节增强完成: {enhance_items[index][0].get('title', '')}"
+            )
+        else:
+            logger.error(f"章节增强失败: {result.error}")
+    enhanced_count = sum(1 for result in results if result.success)
+    logger.info(f"知识增强完成: {enhanced_count} 个章节")
+    state["knowledge_gaps"] = []
+    return state

--- a/backend/services/blog_generator/orchestrator/nodes/review.py
+++ b/backend/services/blog_generator/orchestrator/nodes/review.py
@@ -1,0 +1,233 @@
+"""Review, consistency, and revision node handlers."""
+
+import logging
+
+from . import is_enabled, resolve_style
+from .writing import _content_word_count, _log_word_count_diff
+
+
+logger = logging.getLogger("services.blog_generator.generator")
+
+
+def reviewer_node(state, *, reviewer, tracker, configured_style):
+    logger.info("=== Step 7: 质量审核 ===")
+    style = resolve_style(state, configured_style)
+    revision_count = state.get("revision_count", 0)
+    if revision_count >= style.max_revision_rounds:
+        logger.info(
+            f"[Reviewer] 已达最大修订轮数 ({style.max_revision_rounds})，跳过 R2 审核"
+        )
+        state["review_approved"] = True
+        return state
+
+    state = reviewer.run(state)
+    consistency_issues = state.get("thread_issues", []) + state.get(
+        "voice_issues", []
+    )
+    if consistency_issues:
+        state["review_issues"] = state.get("review_issues", []) + consistency_issues
+        logger.info(f"[Reviewer] 合并一致性检查问题: {len(consistency_issues)} 条")
+    tracker.log_review_score(
+        score=state.get("review_score", 0),
+        round_num=state.get("revision_count", 0),
+        summary=(
+            f"issues={len(state.get('review_issues', []))} "
+            f"approved={state.get('review_approved', False)}"
+        ),
+    )
+    return state
+
+
+def revision_node(
+    state,
+    *,
+    writer,
+    parallel_executor,
+    configured_style,
+    task_config_factory,
+):
+    logger.info("=== Step 7.1: 修订 ===")
+    before_count = _content_word_count(state)
+    state["revision_count"] = state.get("revision_count", 0) + 1
+    review_issues = state.get("review_issues", [])
+    if not review_issues:
+        logger.info("没有需要修订的问题")
+        return state
+    if resolve_style(state, configured_style).revision_strategy == "correct_only":
+        revision_correct_only(
+            state,
+            review_issues,
+            writer=writer,
+            parallel_executor=parallel_executor,
+            task_config_factory=task_config_factory,
+        )
+    else:
+        revision_enhance(
+            state,
+            review_issues,
+            writer=writer,
+            parallel_executor=parallel_executor,
+            task_config_factory=task_config_factory,
+        )
+    _log_word_count_diff("修订", before_count, _content_word_count(state))
+    return state
+
+
+def revision_correct_only(
+    state,
+    review_issues,
+    *,
+    writer,
+    parallel_executor,
+    task_config_factory,
+):
+    section_issues = {}
+    for issue in review_issues:
+        section_issues.setdefault(issue.get("section_id", ""), []).append({
+            "severity": issue.get("severity", "medium"),
+            "description": issue.get("description", ""),
+            "affected_content": issue.get("affected_content", ""),
+        })
+    tasks = []
+    for index, (section_id, issues) in enumerate(section_issues.items(), 1):
+        for section in state.get("sections", []):
+            if section.get("id") == section_id:
+                section_title = section.get("title", section_id)
+                tasks.append({
+                    "name": f"更正-{section_title}",
+                    "fn": writer.correct_section,
+                    "kwargs": {
+                        "original_content": section.get("content", ""),
+                        "issues": issues,
+                        "section_title": section_title,
+                        "progress_info": f"[{index}/{len(section_issues)}]",
+                    },
+                    "_section_id": section_id,
+                })
+                break
+    results = parallel_executor.run_parallel(
+        tasks,
+        config=task_config_factory(name="revision_correct", timeout_seconds=120),
+    )
+    _apply_revision_results(state, tasks, results, "章节更正失败")
+
+
+def revision_enhance(
+    state,
+    review_issues,
+    *,
+    writer,
+    parallel_executor,
+    task_config_factory,
+):
+    tasks = []
+    for index, issue in enumerate(review_issues, 1):
+        section_id = issue.get("section_id", "")
+        for section in state.get("sections", []):
+            if section.get("id") == section_id:
+                section_title = section.get("title", section_id)
+                tasks.append({
+                    "name": f"修订-{section_title}",
+                    "fn": writer.enhance_section,
+                    "kwargs": {
+                        "original_content": section.get("content", ""),
+                        "vague_points": [{
+                            "location": section_title,
+                            "issue": issue.get("description", ""),
+                            "question": issue.get("suggestion", ""),
+                            "suggestion": "根据审核建议修改",
+                        }],
+                        "section_title": section_title,
+                        "progress_info": f"[{index}/{len(review_issues)}]",
+                    },
+                    "_section_id": section_id,
+                })
+                break
+    results = parallel_executor.run_parallel(
+        tasks,
+        config=task_config_factory(name="revision_enhance", timeout_seconds=240),
+    )
+    _apply_revision_results(state, tasks, results, "章节修订失败")
+
+
+def _apply_revision_results(state, tasks, results, error_prefix):
+    for index, result in enumerate(results):
+        if result.success:
+            target_id = tasks[index]["_section_id"]
+            for section in state.get("sections", []):
+                if section.get("id") == target_id:
+                    section["content"] = result.result
+                    break
+        else:
+            logger.error(f"{error_prefix}: {result.error}")
+
+
+def cross_section_dedup_node(
+    state,
+    *,
+    getenv,
+    deduplicator_factory,
+    llm_client,
+):
+    if getenv("CROSS_SECTION_DEDUP_ENABLED", "false").lower() != "true":
+        return state
+    sections = state.get("sections", [])
+    if len(sections) < 2:
+        return state
+    logger.info("=== Step 5.5: 跨章节语义去重 ===")
+    try:
+        deduplicator = deduplicator_factory(llm_client=llm_client)
+        state["sections"] = deduplicator.deduplicate(sections)
+    except Exception as error:
+        logger.warning(f"[Dedup] 异常，跳过去重: {error}")
+    return state
+
+
+def consistency_check_node(
+    state,
+    *,
+    configured_style,
+    env_thread_check,
+    env_voice_check,
+    thread_checker,
+    voice_checker,
+    parallel_executor,
+    task_config_factory,
+):
+    sections = state.get("sections", [])
+    if len(sections) < 2:
+        state["thread_issues"] = []
+        state["voice_issues"] = []
+        return state
+    style = resolve_style(state, configured_style)
+    thread_enabled = is_enabled(
+        env_thread_check, style.enable_thread_check
+    )
+    voice_enabled = is_enabled(env_voice_check, style.enable_voice_check)
+    if not thread_enabled and not voice_enabled:
+        state["thread_issues"] = []
+        state["voice_issues"] = []
+        return state
+
+    logger.info("=== Step 6.5: 一致性检查（叙事 + 语气）===")
+    tasks = []
+    if thread_enabled:
+        tasks.append({"name": "叙事一致性", "fn": thread_checker.run, "args": (state,)})
+    if voice_enabled:
+        tasks.append({"name": "语气一致性", "fn": voice_checker.run, "args": (state,)})
+    results = parallel_executor.run_parallel(
+        tasks,
+        config=task_config_factory(name="consistency_check", timeout_seconds=120),
+    )
+    for result in results:
+        if not result.success:
+            logger.error(f"[ConsistencyCheck] {result.task_name} 异常: {result.error}")
+    if not thread_enabled:
+        state["thread_issues"] = []
+    if not voice_enabled:
+        state["voice_issues"] = []
+    logger.info(
+        f"[ConsistencyCheck] 完成: 叙事问题 {len(state.get('thread_issues', []))}, "
+        f"语气问题 {len(state.get('voice_issues', []))}"
+    )
+    return state

--- a/backend/services/blog_generator/orchestrator/nodes/writing.py
+++ b/backend/services/blog_generator/orchestrator/nodes/writing.py
@@ -1,0 +1,214 @@
+"""Writing and section-improvement node handlers."""
+
+import logging
+
+from . import is_enabled, resolve_style, validate_layer
+
+
+logger = logging.getLogger("services.blog_generator.generator")
+
+
+def _content_word_count(state):
+    return sum(
+        len(section.get("content", ""))
+        for section in state.get("sections", [])
+        if section.get("content")
+    )
+
+
+def _log_word_count_diff(agent_name, before, after):
+    difference = after - before
+    suffix = f"+{difference} 字" if difference >= 0 else f"{difference} 字"
+    logger.info(f"📊 [{agent_name}] 字数变化: {before} → {after} ({suffix})")
+
+
+def writer_node(state, *, writer, layer_validator, memory_storage, configured_style):
+    logger.info("=== Step 3: 内容撰写 ===")
+    validate_layer(layer_validator, "content", state)
+    if memory_storage:
+        try:
+            memory_injection = memory_storage.format_for_injection(
+                state.get("user_id", "default")
+            )
+            if memory_injection:
+                background = state.get("background_knowledge", "")
+                state["background_knowledge"] = (
+                    f"{background}\n\n{memory_injection}"
+                    if background
+                    else memory_injection
+                )
+                logger.info(f"注入用户记忆: {len(memory_injection)} 字符")
+        except Exception as error:
+            logger.debug(f"用户记忆注入跳过: {error}")
+
+    persona_prompt = resolve_style(state, configured_style).get_persona_prompt()
+    if persona_prompt:
+        state["_persona_prompt"] = persona_prompt
+        logger.info(f"[41.10] 注入人设 Prompt: {persona_prompt[:60]}...")
+
+    before_count = _content_word_count(state)
+    result = writer.run(state)
+    _log_word_count_diff("Writer", before_count, _content_word_count(result))
+    if not result.get("accumulated_knowledge"):
+        result["accumulated_knowledge"] = result.get("background_knowledge", "")
+    return result
+
+
+def questioner_node(state, *, questioner):
+    logger.info("=== Step 4: 追问检查 ===")
+    return questioner.run(state)
+
+
+def deepen_content_node(
+    state,
+    *,
+    writer,
+    parallel_executor,
+    tracker,
+    task_config_factory,
+):
+    logger.info("=== Step 4.1: 内容深化 ===")
+    before_count = _content_word_count(state)
+    state["questioning_count"] = state.get("questioning_count", 0) + 1
+    sections_to_deepen = [
+        result
+        for result in state.get("question_results", [])
+        if not result.get("is_detailed_enough", True)
+    ]
+    total_to_deepen = len(sections_to_deepen)
+    if total_to_deepen == 0:
+        logger.info("没有需要深化的章节")
+        return state
+
+    tasks = []
+    for index, result in enumerate(sections_to_deepen, 1):
+        section_id = result.get("section_id", "")
+        for section in state.get("sections", []):
+            if section.get("id") == section_id:
+                section_title = section.get("title", section_id)
+                tasks.append({
+                    "name": f"深化-{section_title}",
+                    "fn": writer.enhance_section,
+                    "kwargs": {
+                        "original_content": section.get("content", ""),
+                        "vague_points": result.get("vague_points", []),
+                        "section_title": section_title,
+                        "progress_info": f"[{index}/{total_to_deepen}]",
+                    },
+                    "_section_id": section_id,
+                })
+                break
+    results = parallel_executor.run_parallel(
+        tasks,
+        config=task_config_factory(name="content_deepen", timeout_seconds=120),
+    )
+    for index, result in enumerate(results):
+        if result.success:
+            target_id = tasks[index]["_section_id"]
+            for section in state.get("sections", []):
+                if section.get("id") == target_id:
+                    section["content"] = result.result
+                    logger.info(f"章节深化完成: {section.get('title', '')}")
+                    break
+        else:
+            logger.error(f"章节深化失败: {result.error}")
+
+    after_count = _content_word_count(state)
+    _log_word_count_diff("内容深化", before_count, after_count)
+    tracker.log_deepen_snapshot(
+        round_num=state.get("questioning_count", 0),
+        sections_deepened=total_to_deepen,
+        chars_added=after_count - before_count,
+    )
+    return state
+
+
+def section_evaluate_node(
+    state,
+    *,
+    questioner,
+    tracker,
+    configured_style,
+):
+    style = resolve_style(state, configured_style)
+    if not is_enabled(
+        "SECTION_EVAL_ENABLED", getattr(style, "enable_thread_check", True)
+    ):
+        logger.info("段落评估已禁用，跳过")
+        state["section_evaluations"] = []
+        state["needs_section_improvement"] = False
+        return state
+
+    logger.info("=== Step 4.2: 段落多维度评估 ===")
+    sections = state.get("sections", [])
+    evaluations = []
+    needs_improvement = False
+    for index, section in enumerate(sections):
+        evaluation = questioner.evaluate_section(
+            section_content=section.get("content", ""),
+            section_title=section.get("title", ""),
+            prev_summary=sections[index - 1].get("title", "") if index > 0 else "",
+            next_preview=(
+                sections[index + 1].get("title", "")
+                if index < len(sections) - 1
+                else ""
+            ),
+        )
+        evaluation["section_idx"] = index
+        evaluations.append(evaluation)
+        if evaluation["overall_quality"] < 7.0:
+            needs_improvement = True
+            logger.info(
+                f"  段落 [{section.get('title', '')}] 需改进: "
+                f"overall={evaluation['overall_quality']}"
+            )
+    state["section_evaluations"] = evaluations
+    state["needs_section_improvement"] = needs_improvement
+    average = sum(
+        evaluation["overall_quality"] for evaluation in evaluations
+    ) / max(len(evaluations), 1)
+    logger.info(f"段落评估完成: 平均分 {average:.1f}, 需改进={needs_improvement}")
+    for evaluation in evaluations:
+        tracker.log_section_evaluation(
+            section_title=sections[evaluation.get("section_idx", 0)].get("title", ""),
+            scores=evaluation.get("scores", {}),
+            overall=evaluation["overall_quality"],
+        )
+    return state
+
+
+def section_improve_node(state, *, writer, tracker):
+    logger.info("=== Step 4.3: 段落精准改进 ===")
+    evaluations = state.get("section_evaluations", [])
+    sections = state.get("sections", [])
+    improved_count = 0
+    for evaluation in evaluations:
+        index = evaluation.get("section_idx", -1)
+        if (
+            evaluation["overall_quality"] >= 7.0
+            or index < 0
+            or index >= len(sections)
+        ):
+            continue
+        section = sections[index]
+        section["content"] = writer.improve_section(
+            original_content=section.get("content", ""),
+            critique=evaluation,
+            section_title=section.get("title", ""),
+        )
+        improved_count += 1
+    state["section_improve_count"] = state.get("section_improve_count", 0) + 1
+    logger.info(
+        f"段落改进完成: 改进了 {improved_count} 个段落 "
+        f"(第 {state['section_improve_count']} 轮)"
+    )
+    new_average = sum(
+        evaluation["overall_quality"] for evaluation in evaluations
+    ) / max(len(evaluations), 1)
+    tracker.log_section_improve_snapshot(
+        round_num=state["section_improve_count"],
+        improved_count=improved_count,
+        avg_score_before=state.get("prev_section_avg_score", 0),
+        avg_score_after=new_average,
+    )
+    return state

--- a/backend/tests/architecture/test_generation_orchestration_boundaries.py
+++ b/backend/tests/architecture/test_generation_orchestration_boundaries.py
@@ -39,6 +39,7 @@ def test_extracted_orchestration_does_not_depend_on_api_or_flask():
         ORCHESTRATOR_ROOT / name
         for name in ("graph_builder.py", "execution_runner.py")
     )
+    paths.extend((ORCHESTRATOR_ROOT / "nodes").glob("*.py"))
 
     for path in paths:
         illegal = _top_level_imports(path) & {"api", "routes", "flask"}
@@ -53,9 +54,47 @@ def test_extracted_orchestration_does_not_depend_on_api_or_flask():
 def test_generator_facade_does_not_build_or_execute_graph_directly():
     path = BACKEND_ROOT / "services" / "blog_generator" / "generator.py"
 
-    assert _method_calls(path, "BlogGenerator", "_build_workflow") == {"build"}
+    assert _method_calls(path, "BlogGenerator", "_build_workflow") == {
+        "_bind_node_handlers",
+        "_bind_routing_handlers",
+        "build",
+    }
     assert "invoke" not in _method_calls(path, "BlogGenerator", "generate")
     assert "stream" not in _method_calls(path, "BlogGenerator", "generate_stream")
+
+
+def test_generator_has_no_node_methods_and_graph_builder_has_no_generator_dependency():
+    generator_path = BACKEND_ROOT / "services/blog_generator/generator.py"
+    generator_tree = ast.parse(generator_path.read_text(encoding="utf-8"))
+    generator_class = next(
+        node for node in generator_tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "BlogGenerator"
+    )
+    assert not [
+        node.name for node in generator_class.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name.endswith("_node")
+    ]
+
+    builder_path = ORCHESTRATOR_ROOT / "graph_builder.py"
+    builder_tree = ast.parse(builder_path.read_text(encoding="utf-8"))
+    init = next(
+        node for node in ast.walk(builder_tree)
+        if isinstance(node, ast.FunctionDef) and node.name == "__init__"
+    )
+    assert "generator" not in [argument.arg for argument in init.args.args]
+
+    violations = []
+    for path in (ORCHESTRATOR_ROOT / "nodes").glob("*.py"):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in tree.body:
+            if isinstance(node, ast.FunctionDef):
+                parameters = {
+                    argument.arg for argument in [*node.args.args, *node.args.kwonlyargs]
+                }
+                if parameters & {"generator", "context"}:
+                    violations.append(f"{path.name}:{node.name}")
+    assert not violations
 
 
 def test_blog_service_generation_paths_delegate_result_finalization():

--- a/backend/tests/architecture/test_shared_state_contract_boundaries.py
+++ b/backend/tests/architecture/test_shared_state_contract_boundaries.py
@@ -2,6 +2,7 @@ import ast
 from pathlib import Path
 
 from services.blog_generator.schemas.state_contracts import NODE_STATE_CONTRACTS
+from services.blog_generator.orchestrator.graph_builder import NODE_NAMES
 
 
 BACKEND_ROOT = Path(__file__).resolve().parents[2]
@@ -45,34 +46,15 @@ def test_shared_state_uses_named_aliases_for_stable_payloads():
 
 
 def test_contract_nodes_use_the_single_registration_boundary():
-    generator_tree = ast.parse(
-        (BACKEND_ROOT / "services/blog_generator/generator.py").read_text()
-    )
     builder_tree = ast.parse(
         (
             BACKEND_ROOT
             / "services/blog_generator/orchestrator/graph_builder.py"
         ).read_text()
     )
-    build_workflow = _function(builder_tree, "build")
-    registered = {
-        item.elts[0].value
-        for node in build_workflow.body
-        if isinstance(node, ast.Assign)
-        and any(
-            isinstance(target, ast.Name) and target.id == "nodes"
-            for target in node.targets
-        )
-        and isinstance(node.value, (ast.Tuple, ast.List))
-        for item in node.value.elts
-        if isinstance(item, (ast.Tuple, ast.List))
-        and item.elts
-        and isinstance(item.elts[0], ast.Constant)
-    }
+    assert set(NODE_STATE_CONTRACTS) <= set(NODE_NAMES)
 
-    assert set(NODE_STATE_CONTRACTS) <= registered
-
-    add_node = _function(generator_tree, "_add_node")
+    add_node = _function(builder_tree, "_add_node")
     called_functions = {
         call.func.id
         for call in ast.walk(add_node)

--- a/backend/tests/test_68_01_architecture.py
+++ b/backend/tests/test_68_01_architecture.py
@@ -222,13 +222,13 @@ class TestGeneratorStyleIntegration:
         assert style.max_revision_rounds == 1  # mini
 
     def test_is_enabled_both_true(self):
-        gen = self._make_generator()
-        assert gen._is_enabled(True, True) is True
+        from services.blog_generator.orchestrator.nodes import is_enabled
+        assert is_enabled(True, True) is True
 
     def test_is_enabled_env_false(self):
-        gen = self._make_generator()
-        assert gen._is_enabled(False, True) is False
+        from services.blog_generator.orchestrator.nodes import is_enabled
+        assert is_enabled(False, True) is False
 
     def test_is_enabled_style_false(self):
-        gen = self._make_generator()
-        assert gen._is_enabled(True, False) is False
+        from services.blog_generator.orchestrator.nodes import is_enabled
+        assert is_enabled(True, False) is False

--- a/backend/tests/test_69_05_session_tracker.py
+++ b/backend/tests/test_69_05_session_tracker.py
@@ -167,37 +167,37 @@ class TestGeneratorTrackerIntegration:
     def test_reviewer_node_calls_tracker(self):
         """ST12: _reviewer_node 调用 tracker.log_review_score"""
         import inspect
-        from services.blog_generator.generator import BlogGenerator
-        source = inspect.getsource(BlogGenerator._reviewer_node)
-        assert "self.tracker.log_review_score" in source
+        from services.blog_generator.orchestrator.nodes.review import reviewer_node
+        source = inspect.getsource(reviewer_node)
+        assert "tracker.log_review_score" in source
 
     def test_section_evaluate_node_calls_tracker(self):
         """ST13: _section_evaluate_node 调用 tracker.log_section_evaluation"""
         import inspect
-        from services.blog_generator.generator import BlogGenerator
-        source = inspect.getsource(BlogGenerator._section_evaluate_node)
-        assert "self.tracker.log_section_evaluation" in source
+        from services.blog_generator.orchestrator.nodes.writing import section_evaluate_node
+        source = inspect.getsource(section_evaluate_node)
+        assert "tracker.log_section_evaluation" in source
 
     def test_section_improve_node_calls_tracker(self):
         """ST14: _section_improve_node 调用 tracker.log_section_improve_snapshot"""
         import inspect
-        from services.blog_generator.generator import BlogGenerator
-        source = inspect.getsource(BlogGenerator._section_improve_node)
-        assert "self.tracker.log_section_improve_snapshot" in source
+        from services.blog_generator.orchestrator.nodes.writing import section_improve_node
+        source = inspect.getsource(section_improve_node)
+        assert "tracker.log_section_improve_snapshot" in source
 
     def test_deepen_content_node_calls_tracker(self):
         """ST14b: _deepen_content_node 调用 tracker.log_deepen_snapshot"""
         import inspect
-        from services.blog_generator.generator import BlogGenerator
-        source = inspect.getsource(BlogGenerator._deepen_content_node)
-        assert "self.tracker.log_deepen_snapshot" in source
+        from services.blog_generator.orchestrator.nodes.writing import deepen_content_node
+        source = inspect.getsource(deepen_content_node)
+        assert "tracker.log_deepen_snapshot" in source
 
     def test_coder_and_artist_node_calls_tracker(self):
         """ST14c: _wait_for_images_node 调用 tracker.log_image_generation（配图异步化后 tracker 移至此处）"""
         import inspect
-        from services.blog_generator.generator import BlogGenerator
-        source = inspect.getsource(BlogGenerator._wait_for_images_node)
-        assert "self.tracker.log_image_generation" in source
+        from services.blog_generator.orchestrator.nodes.finalization import wait_for_images_node
+        source = inspect.getsource(wait_for_images_node)
+        assert "tracker.log_image_generation" in source
 
 
 # ========== ST15-ST17: Agent 清理验证 ==========

--- a/backend/tests/test_background_investigation.py
+++ b/backend/tests/test_background_investigation.py
@@ -1,6 +1,6 @@
 from services.blog_generator.schemas.state import SharedState
 from services.blog_generator.blog_service import _normalize_research_result
-from services.blog_generator.generator import BlogGenerator
+from services.blog_generator.orchestrator.nodes.research import researcher_node
 
 
 def test_shared_state_preserves_skip_researcher_flag():
@@ -24,7 +24,6 @@ def test_skipped_researcher_normalizes_empty_event_fields():
 
 
 def test_skipped_researcher_provides_writer_safe_defaults():
-    generator = object.__new__(BlogGenerator)
     state = {
         "skip_researcher": True,
         "background_knowledge": None,
@@ -34,7 +33,11 @@ def test_skipped_researcher_provides_writer_safe_defaults():
         "knowledge_source_stats": None,
     }
 
-    result = generator._researcher_node(state)
+    result = researcher_node(
+        state,
+        researcher=None,
+        layer_validator=None,
+    )
 
     assert result["background_knowledge"] == ""
     assert result["key_concepts"] == []

--- a/backend/tests/test_blog_completion_event.py
+++ b/backend/tests/test_blog_completion_event.py
@@ -94,6 +94,8 @@ def test_run_generation_reports_failed_state_without_saving_history():
         llm=MagicMock(),
         researcher=SimpleNamespace(search_service=None),
         writer=SimpleNamespace(),
+        _configure_planner_runtime=MagicMock(),
+        _configure_execution_runtime=MagicMock(),
     )
     service._interrupted_tasks = {}
     generate_cover_image = MagicMock()

--- a/backend/tests/test_mini_blog_v2.py
+++ b/backend/tests/test_mini_blog_v2.py
@@ -16,14 +16,14 @@ class TestWordCountHelpers:
     
     def test_get_content_word_count_empty(self):
         """测试空 state"""
-        from services.blog_generator.generator import _get_content_word_count
+        from services.blog_generator.orchestrator.nodes.writing import _content_word_count
         
         state = {'sections': []}
-        assert _get_content_word_count(state) == 0
+        assert _content_word_count(state) == 0
     
     def test_get_content_word_count_with_content(self):
         """测试有内容的 state"""
-        from services.blog_generator.generator import _get_content_word_count
+        from services.blog_generator.orchestrator.nodes.writing import _content_word_count
         
         state = {
             'sections': [
@@ -32,19 +32,19 @@ class TestWordCountHelpers:
                 {'content': ''},  # 0 字
             ]
         }
-        assert _get_content_word_count(state) == 13
+        assert _content_word_count(state) == 13
     
     def test_get_content_word_count_no_sections(self):
         """测试没有 sections 字段"""
-        from services.blog_generator.generator import _get_content_word_count
+        from services.blog_generator.orchestrator.nodes.writing import _content_word_count
         
         state = {}
-        assert _get_content_word_count(state) == 0
+        assert _content_word_count(state) == 0
     
     def test_log_word_count_diff_positive(self, caplog):
         """测试字数增加的日志"""
         import logging
-        from services.blog_generator.generator import _log_word_count_diff
+        from services.blog_generator.orchestrator.nodes.writing import _log_word_count_diff
         
         with caplog.at_level(logging.INFO):
             _log_word_count_diff("Writer", 100, 500)
@@ -54,7 +54,7 @@ class TestWordCountHelpers:
     def test_log_word_count_diff_negative(self, caplog):
         """测试字数减少的日志"""
         import logging
-        from services.blog_generator.generator import _log_word_count_diff
+        from services.blog_generator.orchestrator.nodes.writing import _log_word_count_diff
         
         with caplog.at_level(logging.INFO):
             _log_word_count_diff("修订", 500, 400)
@@ -265,17 +265,18 @@ class TestMiniModeCorrectSection:
         """测试 Mini 模式修订使用 correct_section"""
         # 验证 generator.py 中的修订逻辑
         import inspect
-        from services.blog_generator.generator import BlogGenerator
-
-        generator = BlogGenerator.__new__(BlogGenerator)
+        from services.blog_generator.orchestrator.nodes.review import (
+            revision_correct_only,
+            revision_node,
+        )
 
         # _revision_node 委托给 _revision_correct_only（correct_only 策略）
-        source_node = inspect.getsource(generator._revision_node)
+        source_node = inspect.getsource(revision_node)
         assert "revision_strategy" in source_node
         assert "correct_only" in source_node
 
         # _revision_correct_only 中实际调用 correct_section
-        source_correct = inspect.getsource(generator._revision_correct_only)
+        source_correct = inspect.getsource(revision_correct_only)
         assert "correct_section" in source_correct
 
 

--- a/backend/tests/test_outline_auto_confirm.py
+++ b/backend/tests/test_outline_auto_confirm.py
@@ -7,13 +7,11 @@ the planner node should skip the interactive interrupt and auto-confirm the outl
 
 import os
 import logging
-import types
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-# Import the real _planner_node method to bind to our mock object
-from services.blog_generator.generator import BlogGenerator
+from services.blog_generator.orchestrator.nodes.research import planner_node
 
 
 def _make_planner_result():
@@ -34,32 +32,42 @@ def _make_planner_result():
 
 @pytest.fixture
 def mock_generator():
-    """Create a lightweight mock with the real _planner_node bound to it."""
+    """Create a lightweight module-function planner harness."""
     gen = MagicMock()
-    # Bind the real _planner_node method
-    gen._planner_node = types.MethodType(BlogGenerator._planner_node, gen)
-    # Configure attributes used by _planner_node
     gen._interactive = True
-    gen._outline_stream_callback = None
-    gen._writing_skill_manager = None
     gen.planner.run = MagicMock(return_value=_make_planner_result())
+    gen._interrupt = MagicMock()
+
+    def run(state):
+        return planner_node(
+            state,
+            planner=gen.planner,
+            layer_validator=None,
+            on_stream=None,
+            interactive=gen._interactive,
+            writing_skill_manager=None,
+            llm_client=MagicMock(),
+            interrupt_fn=gen._interrupt,
+            getenv=os.getenv,
+            image_preplanner_factory=MagicMock(),
+        )
+
+    gen._planner_node = run
     return gen
 
 
 class TestOutlineAutoConfirmMini:
     """Tests: mini mode should auto-confirm outline without calling interrupt."""
 
-    @patch('services.blog_generator.generator.interrupt')
-    def test_mini_mode_skips_interrupt(self, mock_interrupt, mock_generator):
+    def test_mini_mode_skips_interrupt(self, mock_generator):
         """When target_length='mini', interrupt() should NOT be called."""
         state = {'target_length': 'mini', 'topic': 'test'}
         result = mock_generator._planner_node(state)
 
-        mock_interrupt.assert_not_called()
+        mock_generator._interrupt.assert_not_called()
         assert result.get('outline') is not None
 
-    @patch('services.blog_generator.generator.interrupt')
-    def test_mini_mode_logs_auto_confirm(self, mock_interrupt, mock_generator, caplog):
+    def test_mini_mode_logs_auto_confirm(self, mock_generator, caplog):
         """When auto-confirming, should log an AutoConfirm message."""
         state = {'target_length': 'mini', 'topic': 'test'}
         with caplog.at_level(logging.INFO):
@@ -71,69 +79,63 @@ class TestOutlineAutoConfirmMini:
 class TestOutlineAutoConfirmEnvVar:
     """Tests: OUTLINE_AUTO_CONFIRM=true should auto-confirm outline."""
 
-    @patch('services.blog_generator.generator.interrupt')
-    def test_env_var_true_skips_interrupt(self, mock_interrupt, mock_generator):
+    def test_env_var_true_skips_interrupt(self, mock_generator):
         """When OUTLINE_AUTO_CONFIRM=true, interrupt() should NOT be called."""
         state = {'target_length': 'medium', 'topic': 'test'}
         with patch.dict(os.environ, {'OUTLINE_AUTO_CONFIRM': 'true'}):
             result = mock_generator._planner_node(state)
 
-        mock_interrupt.assert_not_called()
+        mock_generator._interrupt.assert_not_called()
         assert result.get('outline') is not None
 
-    @patch('services.blog_generator.generator.interrupt')
-    def test_env_var_True_case_insensitive(self, mock_interrupt, mock_generator):
+    def test_env_var_True_case_insensitive(self, mock_generator):
         """OUTLINE_AUTO_CONFIRM should be case-insensitive."""
         state = {'target_length': 'medium', 'topic': 'test'}
         with patch.dict(os.environ, {'OUTLINE_AUTO_CONFIRM': 'True'}):
             mock_generator._planner_node(state)
 
-        mock_interrupt.assert_not_called()
+        mock_generator._interrupt.assert_not_called()
 
-    @patch('services.blog_generator.generator.interrupt')
-    def test_env_var_false_does_not_skip(self, mock_interrupt, mock_generator):
+    def test_env_var_false_does_not_skip(self, mock_generator):
         """When OUTLINE_AUTO_CONFIRM=false and target_length=medium, interrupt IS called."""
-        mock_interrupt.return_value = {"action": "confirm"}
+        mock_generator._interrupt.return_value = {"action": "confirm"}
         state = {'target_length': 'medium', 'topic': 'test'}
         with patch.dict(os.environ, {'OUTLINE_AUTO_CONFIRM': 'false'}):
             mock_generator._planner_node(state)
 
-        mock_interrupt.assert_called_once()
+        mock_generator._interrupt.assert_called_once()
 
 
 class TestOutlineNormalInterrupt:
     """Tests: medium/long mode without env override should call interrupt normally."""
 
-    @patch('services.blog_generator.generator.interrupt')
-    def test_medium_mode_calls_interrupt(self, mock_interrupt, mock_generator):
+    def test_medium_mode_calls_interrupt(self, mock_generator):
         """When target_length='medium' and no env override, interrupt() IS called."""
-        mock_interrupt.return_value = {"action": "confirm"}
+        mock_generator._interrupt.return_value = {"action": "confirm"}
         state = {'target_length': 'medium', 'topic': 'test'}
         with patch.dict(os.environ, {}, clear=False):
             os.environ.pop('OUTLINE_AUTO_CONFIRM', None)
             mock_generator._planner_node(state)
 
-        mock_interrupt.assert_called_once()
+        mock_generator._interrupt.assert_called_once()
 
-    @patch('services.blog_generator.generator.interrupt')
-    def test_long_mode_calls_interrupt(self, mock_interrupt, mock_generator):
+    def test_long_mode_calls_interrupt(self, mock_generator):
         """When target_length='long', interrupt() IS called."""
-        mock_interrupt.return_value = {"action": "confirm"}
+        mock_generator._interrupt.return_value = {"action": "confirm"}
         state = {'target_length': 'long', 'topic': 'test'}
         with patch.dict(os.environ, {}, clear=False):
             os.environ.pop('OUTLINE_AUTO_CONFIRM', None)
             mock_generator._planner_node(state)
 
-        mock_interrupt.assert_called_once()
+        mock_generator._interrupt.assert_called_once()
 
-    @patch('services.blog_generator.generator.interrupt')
-    def test_interrupt_edit_action_still_works(self, mock_interrupt, mock_generator):
+    def test_interrupt_edit_action_still_works(self, mock_generator):
         """When user edits the outline via interrupt, the edit should be applied."""
         edited_outline = {
             'title': 'Edited Title',
             'sections': [{'title': 'New Section'}],
         }
-        mock_interrupt.return_value = {"action": "edit", "outline": edited_outline}
+        mock_generator._interrupt.return_value = {"action": "edit", "outline": edited_outline}
         state = {'target_length': 'medium', 'topic': 'test'}
         with patch.dict(os.environ, {}, clear=False):
             os.environ.pop('OUTLINE_AUTO_CONFIRM', None)
@@ -146,11 +148,10 @@ class TestOutlineNormalInterrupt:
 class TestOutlineAutoConfirmNonInteractive:
     """Tests: non-interactive mode should never call interrupt regardless."""
 
-    @patch('services.blog_generator.generator.interrupt')
-    def test_non_interactive_skips_interrupt(self, mock_interrupt, mock_generator):
+    def test_non_interactive_skips_interrupt(self, mock_generator):
         """When _interactive=False, interrupt should not be called even for medium."""
         mock_generator._interactive = False
         state = {'target_length': 'medium', 'topic': 'test'}
         mock_generator._planner_node(state)
 
-        mock_interrupt.assert_not_called()
+        mock_generator._interrupt.assert_not_called()

--- a/backend/tests/unit/test_101_113_interrupt_unit.py
+++ b/backend/tests/unit/test_101_113_interrupt_unit.py
@@ -9,8 +9,27 @@
 5. interrupt 数据结构正确性
 """
 
+import os
+
 import pytest
 from unittest.mock import MagicMock, patch, PropertyMock
+
+from services.blog_generator.orchestrator.nodes.research import planner_node
+
+
+def _run_planner(gen, state, interrupt_fn):
+    return planner_node(
+        state,
+        planner=gen.planner,
+        layer_validator=None,
+        on_stream=getattr(gen, "_outline_stream_callback", None),
+        interactive=getattr(gen, "_interactive", False),
+        writing_skill_manager=getattr(gen, "_writing_skill_manager", None),
+        llm_client=MagicMock(),
+        interrupt_fn=interrupt_fn,
+        getenv=os.getenv,
+        image_preplanner_factory=MagicMock(),
+    )
 
 
 class TestPlannerNodeInterrupt:
@@ -54,7 +73,7 @@ class TestPlannerNodeInterrupt:
             gen._writing_skill_manager = None
 
             state = {'topic': 'test'}
-            result = gen._planner_node(state)
+            result = _run_planner(gen, state, mock_interrupt)
 
             # interrupt 应该被调用
             mock_interrupt.assert_called_once()
@@ -82,7 +101,7 @@ class TestPlannerNodeInterrupt:
             gen._writing_skill_manager = None
 
             state = {'topic': 'test'}
-            result = gen._planner_node(state)
+            result = _run_planner(gen, state, mock_interrupt)
 
             mock_interrupt.assert_not_called()
 
@@ -111,7 +130,7 @@ class TestPlannerNodeInterrupt:
             gen._layer_validator = None
             gen._writing_skill_manager = None
 
-            result = gen._planner_node({'topic': 'test'})
+            result = _run_planner(gen, {'topic': 'test'}, mock_interrupt)
 
             assert result['outline']['title'] == '修改后的大纲'
             assert result['sections'] == []  # 清空
@@ -132,7 +151,7 @@ class TestPlannerNodeInterrupt:
             gen._layer_validator = None
             gen._writing_skill_manager = None
 
-            result = gen._planner_node({'topic': 'test'})
+            result = _run_planner(gen, {'topic': 'test'}, mock_interrupt)
             mock_interrupt.assert_not_called()
 
 
@@ -258,7 +277,7 @@ class TestInterruptDataStructure:
             gen._layer_validator = None
             gen._writing_skill_manager = None
 
-            gen._planner_node({'topic': 'AI'})
+            _run_planner(gen, {'topic': 'AI'}, mock_interrupt)
 
             call_data = mock_interrupt.call_args[0][0]
             assert 'type' in call_data

--- a/backend/tests/unit/test_async_artist_state_merge.py
+++ b/backend/tests/unit/test_async_artist_state_merge.py
@@ -1,24 +1,18 @@
-import threading
 from concurrent.futures import Future
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
-from services.blog_generator.generator import BlogGenerator
-
-
-def _generator_shell():
-    generator = BlogGenerator.__new__(BlogGenerator)
-    generator._image_tasks = {}
-    generator._image_tasks_lock = threading.Lock()
-    generator.tracker = MagicMock()
-    return generator
+from services.blog_generator.orchestrator.image_task_registry import ImageTaskRegistry
+from services.blog_generator.orchestrator.nodes.finalization import (
+    coder_and_artist_node,
+    wait_for_images_node,
+)
 
 
 def test_coder_and_artist_preprocesses_before_submitting_detached_snapshot():
-    generator = _generator_shell()
-    generator.coder = MagicMock()
-    generator.coder.run.side_effect = lambda state: state
-    generator.artist = MagicMock()
-    generator.artist.preprocess_ascii_flowcharts.return_value = [
+    coder = MagicMock()
+    coder.run.side_effect = lambda state: state
+    artist = MagicMock()
+    artist.preprocess_ascii_flowcharts.return_value = [
         {
             "id": "intro",
             "title": "Intro",
@@ -32,11 +26,14 @@ def test_coder_and_artist_preprocesses_before_submitting_detached_snapshot():
         "code_blocks": [],
     }
 
-    with patch(
-        "services.blog_generator.generator.ThreadPoolExecutor",
-        return_value=executor,
-    ):
-        result = generator._coder_and_artist_node(state)
+    result = coder_and_artist_node(
+        state,
+        coder=coder,
+        artist=artist,
+        image_task_registry=MagicMock(),
+        executor_factory=MagicMock(return_value=executor),
+        uuid_factory=MagicMock(return_value="task_1"),
+    )
 
     submitted_state = executor.submit.call_args.args[1]
     assert result["sections"][0]["content"] == "[IMAGE: converted ASCII]"
@@ -45,7 +42,7 @@ def test_coder_and_artist_preprocesses_before_submitting_detached_snapshot():
 
 
 def test_wait_for_images_merges_image_ids_without_overwriting_newer_content():
-    generator = _generator_shell()
+    registry = ImageTaskRegistry()
     future = Future()
     future.set_result(
         {
@@ -68,7 +65,7 @@ def test_wait_for_images_merges_image_ids_without_overwriting_newer_content():
         }
     )
     executor = MagicMock()
-    generator._image_tasks["task_1"] = (future, executor)
+    registry.register("task_1", future, executor)
     state = {
         "_image_task_id": "task_1",
         "sections": [
@@ -82,7 +79,12 @@ def test_wait_for_images_merges_image_ids_without_overwriting_newer_content():
         "images": [],
     }
 
-    result = generator._wait_for_images_node(state)
+    result = wait_for_images_node(
+        state,
+        image_task_registry=registry,
+        tracker=MagicMock(),
+        timeout=600,
+    )
 
     assert result["sections"][0]["content"] == "newer reviewed content"
     assert result["sections"][0]["image_ids"] == ["existing", "image_1"]

--- a/backend/tests/unit/test_finalization_node_functions.py
+++ b/backend/tests/unit/test_finalization_node_functions.py
@@ -1,0 +1,134 @@
+import inspect
+from concurrent.futures import Future
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from services.blog_generator.orchestrator.image_task_registry import ImageTaskRegistry
+from services.blog_generator.orchestrator.nodes.finalization import (
+    assembler_node,
+    coder_and_artist_node,
+    factcheck_node,
+    humanizer_node,
+    merge_artist_image_ids,
+    summary_generator_node,
+    text_cleanup_node,
+    wait_for_images_node,
+)
+
+
+FINALIZATION_NODES = (
+    coder_and_artist_node,
+    wait_for_images_node,
+    factcheck_node,
+    text_cleanup_node,
+    humanizer_node,
+    assembler_node,
+    summary_generator_node,
+)
+
+
+def test_finalization_nodes_use_explicit_keyword_dependencies():
+    for node in FINALIZATION_NODES:
+        parameters = inspect.signature(node).parameters
+        assert "generator" not in parameters
+        assert "context" not in parameters
+        assert list(parameters)[0] == "state"
+        assert all(
+            parameter.kind is inspect.Parameter.KEYWORD_ONLY
+            for parameter in list(parameters.values())[1:]
+        )
+
+
+def test_coder_and_artist_registers_detached_artist_snapshot():
+    coder = MagicMock()
+    coder.run.side_effect = lambda state: state
+    artist = MagicMock()
+    artist.preprocess_ascii_flowcharts.return_value = [
+        {"id": "one", "content": "converted"}
+    ]
+    executor = MagicMock()
+    future = Future()
+    executor.submit.return_value = future
+    registry = MagicMock()
+    state = {"sections": [{"id": "one", "content": "ascii"}], "code_blocks": []}
+
+    result = coder_and_artist_node(
+        state,
+        coder=coder,
+        artist=artist,
+        image_task_registry=registry,
+        executor_factory=MagicMock(return_value=executor),
+        uuid_factory=MagicMock(return_value="task-1"),
+    )
+
+    submitted_state = executor.submit.call_args.args[1]
+    assert result["_image_task_id"] == "task-1"
+    assert submitted_state is not result
+    assert submitted_state["sections"] is not result["sections"]
+    registry.register.assert_called_once_with("task-1", future, executor)
+
+
+def test_wait_for_images_merges_images_without_overwriting_reviewed_content():
+    registry = ImageTaskRegistry()
+    future = Future()
+    future.set_result({
+        "sections": [
+            {"id": "one", "content": "old", "image_ids": ["image-1"]}
+        ],
+        "images": [{"id": "image-1", "render_method": "mermaid"}],
+        "section_images": ["https://example.com/section.png"],
+    })
+    executor = MagicMock()
+    registry.register("task-1", future, executor)
+    tracker = MagicMock()
+    state = {
+        "_image_task_id": "task-1",
+        "sections": [{"id": "one", "content": "reviewed", "image_ids": []}],
+        "images": [],
+    }
+
+    result = wait_for_images_node(
+        state,
+        image_task_registry=registry,
+        tracker=tracker,
+        timeout=600,
+    )
+
+    assert result["sections"][0]["content"] == "reviewed"
+    assert result["sections"][0]["image_ids"] == ["image-1"]
+    assert result["section_images"] == ["https://example.com/section.png"]
+    tracker.log_image_generation.assert_called_once()
+    executor.shutdown.assert_called_once_with(wait=False)
+
+
+def test_merge_artist_image_ids_deduplicates_and_preserves_order():
+    current = [{"id": "one", "image_ids": ["existing"]}]
+    merge_artist_image_ids(
+        current,
+        [{"id": "one", "image_ids": ["existing", "new"]}],
+    )
+    assert current[0]["image_ids"] == ["existing", "new"]
+
+
+def test_factcheck_mini_skips_optional_agent():
+    factcheck = MagicMock()
+    state = {"target_length": "mini"}
+    assert factcheck_node(
+        state,
+        factcheck=factcheck,
+        configured_style=None,
+        env_factcheck=True,
+    ) is state
+    factcheck.run.assert_not_called()
+
+
+def test_text_cleanup_uses_injected_cleanup_function():
+    cleanup = MagicMock(return_value={"text": "clean", "total_fixes": 1, "stats": {}})
+    state = {"sections": [{"title": "One", "content": "dirty"}]}
+    result = text_cleanup_node(
+        state,
+        cleanup=cleanup,
+        configured_style=SimpleNamespace(enable_text_cleanup=True),
+        env_text_cleanup=True,
+    )
+    assert result["sections"][0]["content"] == "clean"

--- a/backend/tests/unit/test_generation_orchestration_contracts.py
+++ b/backend/tests/unit/test_generation_orchestration_contracts.py
@@ -1,5 +1,6 @@
 import inspect
 import logging
+from functools import partial
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -14,6 +15,38 @@ from services.blog_generator.lifecycle.result_pipeline import (
 from services.blog_generator.lifecycle.task_events import TaskEventBridge
 from services.blog_generator.orchestrator.execution_runner import GraphExecutionRunner
 from services.blog_generator.orchestrator.graph_builder import GraphBuilder
+
+
+NODE_NAMES = {
+    "researcher", "planner", "writer", "check_knowledge", "refine_search",
+    "enhance_with_knowledge", "questioner", "deepen_content",
+    "coder_and_artist", "cross_section_dedup", "section_evaluate",
+    "section_improve", "consistency_check", "reviewer", "revision",
+    "factcheck", "text_cleanup", "humanizer", "wait_for_images",
+    "assembler", "summary_generator",
+}
+
+
+def _named_handler(name):
+    def handler(state):
+        return state
+    handler.__name__ = name
+    return handler
+
+
+def _graph_dependencies():
+    node_handlers = {name: _named_handler(name) for name in NODE_NAMES}
+    routing_handlers = {
+        "should_check_knowledge": _named_handler("_should_check_knowledge"),
+        "should_refine_search": _named_handler("_should_refine_search"),
+        "should_deepen": _named_handler("_should_deepen"),
+        "should_continue_questioning": _named_handler("_should_continue_questioning"),
+        "should_improve_sections": _named_handler("_should_improve_sections"),
+        "should_revise": _named_handler("_should_revise"),
+    }
+    pipeline = MagicMock()
+    pipeline.wrap_node.side_effect = lambda name, handler: handler
+    return node_handlers, routing_handlers, pipeline
 
 
 def test_blog_service_preserves_generation_facade_signatures():
@@ -49,34 +82,74 @@ def test_blog_generator_preserves_build_and_execution_signatures():
     } == expected
 
 
-def test_graph_builder_preserves_workflow_topology():
+def test_planner_runtime_configuration_updates_bound_values_without_self_dependency():
+    generator = BlogGenerator.__new__(BlogGenerator)
+    generator._node_handlers = {
+        "planner": partial(
+            lambda state, *, on_stream, interactive: state,
+            on_stream=None,
+            interactive=False,
+        )
+    }
+    callback = MagicMock()
+
+    generator._configure_planner_runtime(
+        on_stream=callback,
+        interactive=True,
+    )
+
+    assert generator._node_handlers["planner"].keywords == {
+        "on_stream": callback,
+        "interactive": True,
+    }
+
+
+def test_execution_runtime_configuration_updates_all_parallel_node_dependencies():
+    generator = BlogGenerator.__new__(BlogGenerator)
+    old_executor = MagicMock()
+    generator._node_handlers = {
+        name: partial(lambda state, *, parallel_executor: state, parallel_executor=old_executor)
+        for name in (
+            "enhance_with_knowledge",
+            "deepen_content",
+            "consistency_check",
+            "revision",
+        )
+    }
+    new_executor = MagicMock()
+
+    generator._configure_execution_runtime(new_executor)
+
+    assert generator.executor is new_executor
+    assert all(
+        handler.keywords["parallel_executor"] is new_executor
+        for handler in generator._node_handlers.values()
+    )
+
+
+def test_bound_node_dependencies_do_not_retain_generator_instance():
     generator = BlogGenerator(MagicMock())
 
-    workflow = GraphBuilder(generator).build()
+    retained_by = []
+    for node_name, handler in generator._node_handlers.items():
+        for dependency_name, dependency in handler.keywords.items():
+            if getattr(dependency, "__self__", None) is generator:
+                retained_by.append(f"{node_name}.{dependency_name}")
 
-    assert set(workflow.nodes) == {
-        "researcher",
-        "planner",
-        "writer",
-        "check_knowledge",
-        "refine_search",
-        "enhance_with_knowledge",
-        "questioner",
-        "deepen_content",
-        "coder_and_artist",
-        "cross_section_dedup",
-        "section_evaluate",
-        "section_improve",
-        "consistency_check",
-        "reviewer",
-        "revision",
-        "factcheck",
-        "text_cleanup",
-        "humanizer",
-        "wait_for_images",
-        "assembler",
-        "summary_generator",
-    }
+    assert retained_by == []
+
+
+def test_graph_builder_preserves_workflow_topology():
+    node_handlers, routing_handlers, pipeline = _graph_dependencies()
+
+    workflow = GraphBuilder(
+        node_handlers=node_handlers,
+        routing_handlers=routing_handlers,
+        middleware_pipeline=pipeline,
+    ).build()
+
+    assert set(workflow.nodes) == NODE_NAMES
+    assert pipeline.wrap_node.call_count == len(NODE_NAMES)
     assert set(workflow.edges) == {
         ("__start__", "researcher"),
         ("researcher", "planner"),
@@ -136,6 +209,22 @@ def test_graph_builder_preserves_workflow_topology():
             }
         },
     }
+
+
+@pytest.mark.parametrize("mutation", ["missing", "extra"])
+def test_graph_builder_rejects_invalid_node_handler_keys(mutation):
+    node_handlers, routing_handlers, pipeline = _graph_dependencies()
+    if mutation == "missing":
+        node_handlers.pop("writer")
+    else:
+        node_handlers["unexpected"] = MagicMock()
+
+    with pytest.raises(ValueError, match="node handler keys"):
+        GraphBuilder(
+            node_handlers=node_handlers,
+            routing_handlers=routing_handlers,
+            middleware_pipeline=pipeline,
+        )
 
 
 def test_task_event_bridge_attaches_injects_and_closes_idempotently():

--- a/backend/tests/unit/test_image_task_registry.py
+++ b/backend/tests/unit/test_image_task_registry.py
@@ -1,0 +1,84 @@
+from concurrent.futures import Future, ThreadPoolExecutor
+from unittest.mock import MagicMock
+
+import pytest
+
+from services.blog_generator.orchestrator.image_task_registry import ImageTaskRegistry
+
+
+def test_pop_unknown_task_returns_none():
+    assert ImageTaskRegistry().pop("missing") is None
+
+
+def test_pop_returns_future_result_and_shuts_down_executor_once():
+    registry = ImageTaskRegistry()
+    future = Future()
+    future.set_result({"images": ["image-1"]})
+    executor = MagicMock()
+    registry.register("task-1", future, executor)
+
+    assert registry.pop("task-1") == {"images": ["image-1"]}
+    assert registry.pop("task-1") is None
+    executor.shutdown.assert_called_once_with(wait=False)
+
+
+def test_pop_propagates_future_exception_and_still_shuts_down_executor():
+    registry = ImageTaskRegistry()
+    future = Future()
+    future.set_exception(RuntimeError("artist failed"))
+    executor = MagicMock()
+    registry.register("task-1", future, executor)
+
+    with pytest.raises(RuntimeError, match="artist failed"):
+        registry.pop("task-1")
+
+    executor.shutdown.assert_called_once_with(wait=False)
+
+
+def test_pop_forwards_timeout_to_future():
+    registry = ImageTaskRegistry()
+    future = MagicMock()
+    future.result.return_value = {"images": []}
+    executor = MagicMock()
+    registry.register("task-1", future, executor)
+
+    assert registry.pop("task-1", timeout=600) == {"images": []}
+    future.result.assert_called_once_with(timeout=600)
+
+
+def test_discard_cancels_pending_future_and_shuts_down_once():
+    registry = ImageTaskRegistry()
+    future = MagicMock()
+    executor = MagicMock()
+    registry.register("task-1", future, executor)
+
+    registry.discard("task-1")
+    registry.discard("task-1")
+
+    future.cancel.assert_called_once_with()
+    executor.shutdown.assert_called_once_with(wait=False)
+
+
+def test_register_and_pop_are_thread_safe_for_independent_tasks():
+    registry = ImageTaskRegistry()
+    executors = {f"task-{index}": MagicMock() for index in range(20)}
+    futures = {}
+    for task_id in executors:
+        future = Future()
+        future.set_result(task_id)
+        futures[task_id] = future
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        list(
+            pool.map(
+                lambda task_id: registry.register(
+                    task_id, futures[task_id], executors[task_id]
+                ),
+                executors,
+            )
+        )
+        results = list(pool.map(registry.pop, executors))
+
+    assert set(results) == set(executors)
+    for executor in executors.values():
+        executor.shutdown.assert_called_once_with(wait=False)

--- a/backend/tests/unit/test_research_node_functions.py
+++ b/backend/tests/unit/test_research_node_functions.py
@@ -1,0 +1,115 @@
+import inspect
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from services.blog_generator.orchestrator.nodes.research import (
+    check_knowledge_node,
+    enhance_with_knowledge_node,
+    planner_node,
+    refine_search_node,
+    researcher_node,
+)
+
+
+RESEARCH_NODES = (
+    researcher_node,
+    planner_node,
+    check_knowledge_node,
+    refine_search_node,
+    enhance_with_knowledge_node,
+)
+
+
+def test_research_nodes_use_explicit_keyword_dependencies():
+    for node in RESEARCH_NODES:
+        parameters = inspect.signature(node).parameters
+        assert "generator" not in parameters
+        assert "context" not in parameters
+        assert list(parameters)[0] == "state"
+        assert all(
+            parameter.kind is inspect.Parameter.KEYWORD_ONLY
+            for parameter in list(parameters.values())[1:]
+        )
+
+
+def test_researcher_skip_populates_writer_safe_defaults_without_dependencies():
+    researcher = MagicMock()
+    layer_validator = MagicMock()
+    state = {
+        "skip_researcher": True,
+        "background_knowledge": None,
+        "search_results": None,
+        "distilled_sources": None,
+    }
+
+    result = researcher_node(
+        state,
+        researcher=researcher,
+        layer_validator=layer_validator,
+    )
+
+    assert result["background_knowledge"] == ""
+    assert result["search_results"] == []
+    assert result["distilled_sources"] == []
+    researcher.run.assert_not_called()
+    layer_validator.validate_inputs.assert_not_called()
+
+
+def test_planner_auto_confirms_mini_and_injects_writing_skill():
+    planner = MagicMock()
+    planner.run.return_value = {"outline": {"title": "Title", "sections": []}}
+    skill = SimpleNamespace(name="tutorial")
+    skill_manager = MagicMock()
+    skill_manager.match_skill.return_value = skill
+    skill_manager.build_system_prompt_section.return_value = "Use tutorial structure"
+    interrupt = MagicMock()
+
+    result = planner_node(
+        {"topic": "Topic", "article_type": "tutorial", "target_length": "mini"},
+        planner=planner,
+        layer_validator=None,
+        on_stream=None,
+        interactive=True,
+        writing_skill_manager=skill_manager,
+        llm_client=MagicMock(),
+        interrupt_fn=interrupt,
+        getenv=lambda key, default=None: default,
+        image_preplanner_factory=MagicMock(),
+    )
+
+    assert result["_writing_skill_prompt"] == "Use tutorial structure"
+    interrupt.assert_not_called()
+
+
+def test_enhance_with_knowledge_updates_successful_sections_in_order():
+    writer = SimpleNamespace(llm=MagicMock())
+    executor = MagicMock()
+    executor.run_parallel.return_value = [
+        SimpleNamespace(success=True, result="Enhanced one", error=None),
+        SimpleNamespace(success=False, result=None, error="failed"),
+    ]
+    prompt_manager = MagicMock()
+    prompt_manager.render_writer_enhance_with_knowledge.return_value = "prompt"
+    state = {
+        "sections": [
+            {"id": "one", "title": "One", "content": "Old one"},
+            {"id": "two", "title": "Two", "content": "Old two"},
+        ],
+        "knowledge_gaps": [
+            {"section_id": "one"},
+            {"section_id": "two"},
+        ],
+        "accumulated_knowledge": "Knowledge",
+    }
+
+    result = enhance_with_knowledge_node(
+        state,
+        writer=writer,
+        parallel_executor=executor,
+        prompt_manager_factory=MagicMock(return_value=prompt_manager),
+        task_config_factory=MagicMock(return_value="config"),
+    )
+
+    assert result["sections"][0]["content"] == "Enhanced one"
+    assert result["sections"][1]["content"] == "Old two"
+    assert result["knowledge_gaps"] == []

--- a/backend/tests/unit/test_review_node_functions.py
+++ b/backend/tests/unit/test_review_node_functions.py
@@ -1,0 +1,123 @@
+import inspect
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from services.blog_generator.orchestrator.nodes.review import (
+    consistency_check_node,
+    cross_section_dedup_node,
+    reviewer_node,
+    revision_correct_only,
+    revision_enhance,
+    revision_node,
+)
+
+
+REVIEW_FUNCTIONS = (
+    cross_section_dedup_node,
+    consistency_check_node,
+    reviewer_node,
+    revision_node,
+    revision_correct_only,
+    revision_enhance,
+)
+
+
+def test_review_functions_do_not_accept_generator_or_context():
+    for function in REVIEW_FUNCTIONS:
+        parameters = inspect.signature(function).parameters
+        assert "generator" not in parameters
+        assert "context" not in parameters
+
+
+def test_reviewer_skips_second_review_at_revision_limit():
+    reviewer = MagicMock()
+    tracker = MagicMock()
+    style = SimpleNamespace(max_revision_rounds=1)
+    state = {"revision_count": 1}
+
+    result = reviewer_node(
+        state,
+        reviewer=reviewer,
+        tracker=tracker,
+        configured_style=style,
+    )
+
+    assert result["review_approved"] is True
+    reviewer.run.assert_not_called()
+    tracker.log_review_score.assert_not_called()
+
+
+def test_reviewer_merges_consistency_issues_and_tracks_score():
+    reviewer = MagicMock()
+    reviewer.run.side_effect = lambda state: state
+    tracker = MagicMock()
+    state = {
+        "revision_count": 0,
+        "review_score": 8,
+        "review_issues": [{"description": "review"}],
+        "thread_issues": [{"description": "thread"}],
+        "voice_issues": [{"description": "voice"}],
+    }
+
+    result = reviewer_node(
+        state,
+        reviewer=reviewer,
+        tracker=tracker,
+        configured_style=SimpleNamespace(max_revision_rounds=2),
+    )
+
+    assert [issue["description"] for issue in result["review_issues"]] == [
+        "review",
+        "thread",
+        "voice",
+    ]
+    tracker.log_review_score.assert_called_once()
+
+
+def test_revision_correct_only_preserves_section_order():
+    writer = MagicMock()
+    executor = MagicMock()
+    executor.run_parallel.return_value = [
+        SimpleNamespace(success=True, result="Corrected", error=None)
+    ]
+    state = {
+        "sections": [
+            {"id": "one", "title": "One", "content": "Old"},
+            {"id": "two", "title": "Two", "content": "Keep"},
+        ]
+    }
+
+    revision_correct_only(
+        state,
+        [{"section_id": "one", "description": "Fix"}],
+        writer=writer,
+        parallel_executor=executor,
+        task_config_factory=MagicMock(return_value="config"),
+    )
+
+    assert state["sections"][0]["content"] == "Corrected"
+    assert state["sections"][1]["content"] == "Keep"
+
+
+def test_consistency_check_clears_disabled_results():
+    state = {
+        "sections": [{"id": "one"}, {"id": "two"}],
+        "thread_issues": [{"description": "old"}],
+        "voice_issues": [{"description": "old"}],
+    }
+    result = consistency_check_node(
+        state,
+        configured_style=SimpleNamespace(
+            enable_thread_check=False,
+            enable_voice_check=False,
+        ),
+        env_thread_check=True,
+        env_voice_check=True,
+        thread_checker=MagicMock(),
+        voice_checker=MagicMock(),
+        parallel_executor=MagicMock(),
+        task_config_factory=MagicMock(),
+    )
+
+    assert result["thread_issues"] == []
+    assert result["voice_issues"] == []

--- a/backend/tests/unit/test_writing_node_functions.py
+++ b/backend/tests/unit/test_writing_node_functions.py
@@ -1,0 +1,125 @@
+import inspect
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from services.blog_generator.orchestrator.nodes.writing import (
+    deepen_content_node,
+    questioner_node,
+    section_evaluate_node,
+    section_improve_node,
+    writer_node,
+)
+
+
+WRITING_NODES = (
+    writer_node,
+    questioner_node,
+    deepen_content_node,
+    section_evaluate_node,
+    section_improve_node,
+)
+
+
+def test_writing_nodes_use_explicit_keyword_dependencies():
+    for node in WRITING_NODES:
+        parameters = inspect.signature(node).parameters
+        assert "generator" not in parameters
+        assert "context" not in parameters
+        assert list(parameters)[0] == "state"
+        assert all(
+            parameter.kind is inspect.Parameter.KEYWORD_ONLY
+            for parameter in list(parameters.values())[1:]
+        )
+
+
+def test_writer_injects_memory_and_persona_then_initializes_accumulated_knowledge():
+    writer = MagicMock()
+    writer.run.side_effect = lambda state: state
+    memory_storage = MagicMock()
+    memory_storage.format_for_injection.return_value = "Remember concise examples"
+    style = MagicMock()
+    style.get_persona_prompt.return_value = "Write as an engineer"
+    state = {
+        "user_id": "user-1",
+        "background_knowledge": "Background",
+        "sections": [],
+    }
+
+    result = writer_node(
+        state,
+        writer=writer,
+        layer_validator=None,
+        memory_storage=memory_storage,
+        configured_style=style,
+    )
+
+    assert result["background_knowledge"] == (
+        "Background\n\nRemember concise examples"
+    )
+    assert result["_persona_prompt"] == "Write as an engineer"
+    assert result["accumulated_knowledge"] == result["background_knowledge"]
+
+
+def test_deepen_content_updates_only_successful_section_and_tracks_snapshot():
+    writer = MagicMock()
+    executor = MagicMock()
+    executor.run_parallel.return_value = [
+        SimpleNamespace(success=True, result="Deepened", error=None)
+    ]
+    tracker = MagicMock()
+    state = {
+        "sections": [
+            {"id": "one", "title": "One", "content": "Old"},
+            {"id": "two", "title": "Two", "content": "Keep"},
+        ],
+        "question_results": [
+            {
+                "section_id": "one",
+                "is_detailed_enough": False,
+                "vague_points": ["details"],
+            }
+        ],
+    }
+
+    result = deepen_content_node(
+        state,
+        writer=writer,
+        parallel_executor=executor,
+        tracker=tracker,
+        task_config_factory=MagicMock(return_value="config"),
+    )
+
+    assert result["sections"][0]["content"] == "Deepened"
+    assert result["sections"][1]["content"] == "Keep"
+    assert result["questioning_count"] == 1
+    tracker.log_deepen_snapshot.assert_called_once()
+
+
+def test_section_evaluate_disabled_preserves_skip_contract():
+    state = {"sections": [{"title": "One", "content": "Body"}]}
+    result = section_evaluate_node(
+        state,
+        questioner=MagicMock(),
+        tracker=MagicMock(),
+        configured_style=SimpleNamespace(enable_thread_check=False),
+    )
+
+    assert result["section_evaluations"] == []
+    assert result["needs_section_improvement"] is False
+
+
+def test_section_improve_updates_low_scoring_sections_and_tracker():
+    writer = MagicMock()
+    writer.improve_section.return_value = "Improved"
+    tracker = MagicMock()
+    state = {
+        "sections": [{"title": "One", "content": "Old"}],
+        "section_evaluations": [{"section_idx": 0, "overall_quality": 6.5}],
+        "prev_section_avg_score": 6.5,
+    }
+
+    result = section_improve_node(state, writer=writer, tracker=tracker)
+
+    assert result["sections"][0]["content"] == "Improved"
+    assert result["section_improve_count"] == 1
+    tracker.log_section_improve_snapshot.assert_called_once()

--- a/backend/tests/verify_102_features.py
+++ b/backend/tests/verify_102_features.py
@@ -445,12 +445,14 @@ def benefit_full_integration():
     import inspect
     from services.blog_generator.generator import BlogGenerator
     from services.blog_generator.orchestrator.graph_builder import GraphBuilder
+    from services.blog_generator.orchestrator.nodes.research import planner_node
+    from services.blog_generator.orchestrator.nodes.writing import writer_node
 
     init_src = inspect.getsource(BlogGenerator.__init__)
     workflow_src = inspect.getsource(GraphBuilder.build)
-    add_node_src = inspect.getsource(BlogGenerator._add_node)
-    planner_src = inspect.getsource(BlogGenerator._planner_node)
-    writer_src = inspect.getsource(BlogGenerator._writer_node)
+    add_node_src = inspect.getsource(GraphBuilder._add_node)
+    planner_src = inspect.getsource(planner_node)
+    writer_src = inspect.getsource(writer_node)
 
     components = {
         "MiddlewarePipeline": "MiddlewarePipeline" in init_src,
@@ -488,9 +490,9 @@ def benefit_full_integration():
     call_chain["researcher → ToolRegistry (102.08)"] = "_tool_registry" in researcher_src
 
     wraps_contract = (
-        "generator._add_node" in workflow_src
-        and "for node_name, handler in nodes" in workflow_src
-        and "pipeline.wrap_node" in add_node_src
+        "self._add_node" in workflow_src
+        and "for node_name in NODE_NAMES" in workflow_src
+        and "middleware_pipeline.wrap_node" in add_node_src
         and "wrap_node_state_contract" in add_node_src
     )
 


### PR DESCRIPTION
## Summary

- extract 21 LangGraph generation nodes into phase-focused module-level functions with explicit dependencies
- build the graph from validated node/routing handler mappings while preserving topology, middleware, state contracts, APIs, and SSE behavior
- add a thread-safe image task registry and focused architecture/unit coverage for runtime binding, state merging, and resource cleanup

## Test plan

- `cd backend && python -m pytest tests/ -v` - 1489 passed, 12 skipped
- `cd backend && PYTHONPATH=. python tests/verify_102_features.py` - 12 passed
- target E2E suite (TC02/05/06/09/14/15/16) - 13 passed in the combined run; TC15 and TC16 missed the task-id listener window, then each passed in isolated reruns
- `git diff --check`

Part of #159
