### PR TITLE
refactor: extract generation routing policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,12 @@ All notable changes to the Vibe Blog project will be documented in this file.
 ### Changed
 - ♻️ **媒体生成边界** — 将封面图、封面视频、序列视频和视频合并逻辑迁移为显式依赖的模块级函数，移除 `BlogService` 的媒体私有方法并保持降级与 SSE 契约。
 - ♻️ **生成节点函数边界** — 将 21 个 LangGraph 节点迁移为按阶段组织、显式依赖绑定的模块级函数，并让 `GraphBuilder` 通过 handler mapping 建图。
+- ♻️ **生成路由策略边界** — 将 6 个 LangGraph 条件路由迁移为显式 style resolver 依赖的模块级函数，移除 `BlogGenerator` 路由方法并保持分支标识、状态副作用与动态 style 语义。
 
 ### Tests
 - ✨ **媒体 Pipeline 契约** — 覆盖依赖边界、摘要回退、横竖屏、单图与序列分支、事件载荷、顺序保持、合并失败及媒体降级完成流程。
 - ✨ **节点编排回归契约** — 覆盖节点依赖边界、图拓扑、运行时绑定、异步配图资源释放、状态合并及 research/writing/review/finalization 行为。
+- ✨ **路由策略回归契约** — 覆盖 6 个路由分支、循环上限、收敛与问题过滤副作用、真实 LangGraph branch 名称、动态 style 更新及 generator 反向依赖守卫。
 
 ## 2026-08-01
 

--- a/backend/services/blog_generator/generator.py
+++ b/backend/services/blog_generator/generator.py
@@ -7,7 +7,7 @@ import os
 import uuid
 from concurrent.futures import ThreadPoolExecutor
 from functools import partial
-from typing import Dict, Any, Optional, Literal, Callable
+from typing import Dict, Any, Optional, Callable
 
 from langgraph.graph import StateGraph
 from langgraph.checkpoint.memory import MemorySaver
@@ -43,6 +43,16 @@ from .llm_tier_config import get_agent_tier
 from .orchestrator.execution_runner import GraphExecutionRunner
 from .orchestrator.graph_builder import GraphBuilder
 from .orchestrator.image_task_registry import ImageTaskRegistry
+from .orchestrator.routing import (
+    _should_check_knowledge,
+    _should_continue_questioning,
+    _should_deepen,
+    _should_improve_sections,
+    _should_refine_search,
+    _should_revise,
+    RoutingStyleResolver,
+    bind_style_resolver,
+)
 from .orchestrator.nodes.finalization import (
     assembler_node,
     coder_and_artist_node,
@@ -86,6 +96,17 @@ class BlogGenerator:
     
     基于 LangGraph 实现的 Multi-Agent 协同生成系统
     """
+
+    @property
+    def style(self):
+        return self._style
+
+    @style.setter
+    def style(self, value):
+        self._style = value
+        resolver = getattr(self, "_routing_style_resolver", None)
+        if resolver is not None:
+            resolver.configured_style = value
     
     def __init__(
         self,
@@ -206,6 +227,8 @@ class BlogGenerator:
             except Exception as e:
                 logger.warning(f"MemoryStorage 初始化失败: {e}")
 
+        self._routing_style_resolver = RoutingStyleResolver(self.style)
+
         # 构建工作流
         self.workflow = self._build_workflow()
         self.app = None
@@ -219,9 +242,10 @@ class BlogGenerator:
             StateGraph 实例
         """
         self._node_handlers = self._bind_node_handlers()
+        self._routing_handlers = self._bind_routing_handlers()
         return GraphBuilder(
             node_handlers=self._node_handlers,
-            routing_handlers=self._bind_routing_handlers(),
+            routing_handlers=self._routing_handlers,
             middleware_pipeline=self.pipeline,
         ).build()
 
@@ -357,12 +381,24 @@ class BlogGenerator:
 
     def _bind_routing_handlers(self):
         return {
-            "should_check_knowledge": self._should_check_knowledge,
-            "should_refine_search": self._should_refine_search,
-            "should_deepen": self._should_deepen,
-            "should_continue_questioning": self._should_continue_questioning,
-            "should_improve_sections": self._should_improve_sections,
-            "should_revise": self._should_revise,
+            "should_check_knowledge": _should_check_knowledge,
+            "should_refine_search": bind_style_resolver(
+                _should_refine_search,
+                self._routing_style_resolver,
+            ),
+            "should_deepen": bind_style_resolver(
+                _should_deepen,
+                self._routing_style_resolver,
+            ),
+            "should_continue_questioning": bind_style_resolver(
+                _should_continue_questioning,
+                self._routing_style_resolver,
+            ),
+            "should_improve_sections": _should_improve_sections,
+            "should_revise": bind_style_resolver(
+                _should_revise,
+                self._routing_style_resolver,
+            ),
         }
 
     def _configure_planner_runtime(self, *, on_stream, interactive):
@@ -380,30 +416,6 @@ class BlogGenerator:
         ):
             self._node_handlers[node_name].keywords["parallel_executor"] = executor
     
-
-    def _should_improve_sections(self, state: SharedState) -> str:
-        """判断是否需要段落级改进"""
-        if not state.get("needs_section_improvement", False):
-            return "continue"
-
-        improve_count = state.get("section_improve_count", 0)
-        if improve_count >= 2:
-            logger.info("段落改进达到最大轮数(2)，跳过")
-            return "continue"
-
-        # 收敛检测：改进幅度 < 0.3 则停止
-        evaluations = state.get("section_evaluations", [])
-        curr_avg = (
-            sum(e["overall_quality"] for e in evaluations) / max(len(evaluations), 1)
-        )
-        prev_avg = state.get("prev_section_avg_score", 0)
-        if prev_avg > 0 and (curr_avg - prev_avg) < 0.3:
-            logger.info(f"段落改进收敛 ({prev_avg:.1f} → {curr_avg:.1f})，跳过")
-            return "continue"
-
-        state["prev_section_avg_score"] = curr_avg
-        return "improve"
-
 
     def _get_style(self, state: SharedState) -> StyleProfile:
         """获取当前运行的 StyleProfile（实例级 > state 级 > target_length 推断）"""
@@ -428,89 +440,6 @@ class BlogGenerator:
             "recursion_limit": recursion_limit,
         }
 
-
-    def _should_deepen(self, state: SharedState) -> Literal["deepen", "continue"]:
-        """判断是否需要深化内容 — 统一用 StyleProfile 控制"""
-        count = state.get('questioning_count', 0)
-        style = self._get_style(state)
-        max_rounds = style.max_questioning_rounds
-
-        if count >= max_rounds:
-            logger.info(f"[Deepen] 已达最大轮数 {count}/{max_rounds}，停止深化")
-            return "continue"
-
-        if not state.get('all_sections_detailed', True):
-            logger.info(f"[Deepen] 第 {count+1}/{max_rounds} 轮深化")
-            return "deepen"
-
-        return "continue"
-
-    def _should_continue_questioning(self, state: SharedState) -> Literal["questioner", "section_evaluate"]:
-        """深化后判断是否需要继续追问 — 避免已达轮数上限仍执行 questioner"""
-        count = state.get('questioning_count', 0)
-        style = self._get_style(state)
-        max_rounds = style.max_questioning_rounds
-        if count >= max_rounds:
-            logger.info(f"[Deepen] 深化后已达最大轮数 {count}/{max_rounds}，跳过追问")
-            return "section_evaluate"
-        return "questioner"
-
-    def _should_check_knowledge(self, state: SharedState) -> Literal["check", "skip"]:
-        """mini 模式跳过知识空白检查"""
-        target_length = state.get('target_length', 'medium')
-        if target_length == 'mini':
-            logger.info("[check_knowledge] mini 模式，跳过知识空白检查")
-            return "skip"
-        return "check"
-
-    def _should_revise(self, state: SharedState) -> Literal["revision", "assemble"]:
-        """判断是否需要修订 — 由 StyleProfile 控制"""
-        style = self._get_style(state)
-        revision_count = state.get('revision_count', 0)
-
-        # 达到最大修订轮数
-        if revision_count >= style.max_revision_rounds:
-            logger.info(f"已达到最大修订轮数 ({style.max_revision_rounds})，跳过修订")
-            return "assemble"
-
-        review_issues = state.get('review_issues', [])
-
-        # 修订问题过滤（high_only 模式）
-        if style.revision_severity_filter == "high_only":
-            high_issues = [i for i in review_issues if i.get('severity') == 'high']
-            if high_issues:
-                logger.info(f"[{style.revision_severity_filter}] 只处理 {len(high_issues)} 个 high 级别问题")
-                state['review_issues'] = high_issues
-                return "revision"
-            logger.info(f"[{style.revision_severity_filter}] 无 high 级别问题，跳过修订")
-            return "assemble"
-
-        # 完整修订模式
-        if not state.get('review_approved', True):
-            return "revision"
-
-        logger.info("审核通过或修订完成，进入组装")
-        return "assemble"
-
-    def _should_refine_search(self, state: SharedState) -> Literal["search", "continue"]:
-        """判断是否需要细化搜索 — 由 StyleProfile 控制"""
-        style = self._get_style(state)
-        if not style.enable_knowledge_refinement:
-            logger.info("知识增强已禁用，跳过")
-            return "continue"
-
-        gaps = state.get('knowledge_gaps', [])
-        search_count = state.get('search_count', 0)
-        max_count = state.get('max_search_count', 5)
-
-        if gaps and search_count < max_count:
-            important_gaps = [g for g in gaps if g.get('gap_type') in ['missing_data', 'vague_concept']]
-            if important_gaps:
-                logger.info(f"检测到 {len(important_gaps)} 个重要知识空白，触发细化搜索")
-                return "search"
-
-        logger.info("无需细化搜索，继续到追问阶段")
-        return "continue"
 
     def _run_derivative_skills(self, final_state: Dict[str, Any]) -> Dict[str, Any]:
         """37.14/37.16 运行博客衍生物 Skills（MindMap/Flashcard/StudyNote）"""

--- a/backend/services/blog_generator/orchestrator/routing.py
+++ b/backend/services/blog_generator/orchestrator/routing.py
@@ -1,0 +1,154 @@
+"""Module-level routing policies for the generation graph."""
+
+import logging
+from functools import partial, update_wrapper
+from typing import Callable, Literal
+
+from .nodes import resolve_style
+
+
+logger = logging.getLogger("services.blog_generator.generator")
+
+
+class RoutingStyleResolver:
+    def __init__(self, configured_style=None):
+        self.configured_style = configured_style
+
+    def __call__(self, state):
+        return resolve_style(state, self.configured_style)
+
+
+def bind_style_resolver(handler: Callable, style_resolver):
+    return update_wrapper(
+        partial(handler, style_resolver=style_resolver),
+        handler,
+    )
+
+
+def _should_improve_sections(state) -> Literal["improve", "continue"]:
+    if not state.get("needs_section_improvement", False):
+        return "continue"
+
+    improve_count = state.get("section_improve_count", 0)
+    if improve_count >= 2:
+        logger.info("段落改进达到最大轮数(2)，跳过")
+        return "continue"
+
+    evaluations = state.get("section_evaluations", [])
+    current_average = (
+        sum(evaluation["overall_quality"] for evaluation in evaluations)
+        / max(len(evaluations), 1)
+    )
+    previous_average = state.get("prev_section_avg_score", 0)
+    if previous_average > 0 and (current_average - previous_average) < 0.3:
+        logger.info(
+            "段落改进收敛 (%.1f → %.1f)，跳过",
+            previous_average,
+            current_average,
+        )
+        return "continue"
+
+    state["prev_section_avg_score"] = current_average
+    return "improve"
+
+
+def _should_deepen(
+    state, *, style_resolver
+) -> Literal["deepen", "continue"]:
+    count = state.get("questioning_count", 0)
+    style = style_resolver(state)
+    max_rounds = style.max_questioning_rounds
+
+    if count >= max_rounds:
+        logger.info("[Deepen] 已达最大轮数 %s/%s，停止深化", count, max_rounds)
+        return "continue"
+
+    if not state.get("all_sections_detailed", True):
+        logger.info("[Deepen] 第 %s/%s 轮深化", count + 1, max_rounds)
+        return "deepen"
+
+    return "continue"
+
+
+def _should_continue_questioning(
+    state, *, style_resolver
+) -> Literal["questioner", "section_evaluate"]:
+    count = state.get("questioning_count", 0)
+    style = style_resolver(state)
+    max_rounds = style.max_questioning_rounds
+    if count >= max_rounds:
+        logger.info(
+            "[Deepen] 深化后已达最大轮数 %s/%s，跳过追问",
+            count,
+            max_rounds,
+        )
+        return "section_evaluate"
+    return "questioner"
+
+
+def _should_check_knowledge(state) -> Literal["check", "skip"]:
+    if state.get("target_length", "medium") == "mini":
+        logger.info("[check_knowledge] mini 模式，跳过知识空白检查")
+        return "skip"
+    return "check"
+
+
+def _should_revise(
+    state, *, style_resolver
+) -> Literal["revision", "assemble"]:
+    style = style_resolver(state)
+    revision_count = state.get("revision_count", 0)
+
+    if revision_count >= style.max_revision_rounds:
+        logger.info("已达到最大修订轮数 (%s)，跳过修订", style.max_revision_rounds)
+        return "assemble"
+
+    review_issues = state.get("review_issues", [])
+    if style.revision_severity_filter == "high_only":
+        high_issues = [
+            issue for issue in review_issues
+            if issue.get("severity") == "high"
+        ]
+        if high_issues:
+            logger.info(
+                "[%s] 只处理 %s 个 high 级别问题",
+                style.revision_severity_filter,
+                len(high_issues),
+            )
+            state["review_issues"] = high_issues
+            return "revision"
+        logger.info("[%s] 无 high 级别问题，跳过修订", style.revision_severity_filter)
+        return "assemble"
+
+    if not state.get("review_approved", True):
+        return "revision"
+
+    logger.info("审核通过或修订完成，进入组装")
+    return "assemble"
+
+
+def _should_refine_search(
+    state, *, style_resolver
+) -> Literal["search", "continue"]:
+    style = style_resolver(state)
+    if not style.enable_knowledge_refinement:
+        logger.info("知识增强已禁用，跳过")
+        return "continue"
+
+    gaps = state.get("knowledge_gaps", [])
+    search_count = state.get("search_count", 0)
+    max_count = state.get("max_search_count", 5)
+    if gaps and search_count < max_count:
+        important_gaps = [
+            gap for gap in gaps
+            if gap.get("gap_type") in {"missing_data", "vague_concept"}
+        ]
+        if important_gaps:
+            logger.info(
+                "检测到 %s 个重要知识空白，触发细化搜索",
+                len(important_gaps),
+            )
+            return "search"
+
+    logger.info("无需细化搜索，继续到追问阶段")
+    return "continue"

--- a/backend/tests/architecture/test_generation_orchestration_boundaries.py
+++ b/backend/tests/architecture/test_generation_orchestration_boundaries.py
@@ -37,7 +37,7 @@ def test_extracted_orchestration_does_not_depend_on_api_or_flask():
     paths = [*LIFECYCLE_ROOT.glob("*.py")]
     paths.extend(
         ORCHESTRATOR_ROOT / name
-        for name in ("graph_builder.py", "execution_runner.py")
+        for name in ("graph_builder.py", "execution_runner.py", "routing.py")
     )
     paths.extend((ORCHESTRATOR_ROOT / "nodes").glob("*.py"))
 
@@ -63,7 +63,7 @@ def test_generator_facade_does_not_build_or_execute_graph_directly():
     assert "stream" not in _method_calls(path, "BlogGenerator", "generate_stream")
 
 
-def test_generator_has_no_node_methods_and_graph_builder_has_no_generator_dependency():
+def test_generator_has_no_node_or_routing_methods_and_graph_builder_has_no_generator_dependency():
     generator_path = BACKEND_ROOT / "services/blog_generator/generator.py"
     generator_tree = ast.parse(generator_path.read_text(encoding="utf-8"))
     generator_class = next(
@@ -74,6 +74,11 @@ def test_generator_has_no_node_methods_and_graph_builder_has_no_generator_depend
         node.name for node in generator_class.body
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
         and node.name.endswith("_node")
+    ]
+    assert not [
+        node.name for node in generator_class.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name.startswith("_should_")
     ]
 
     builder_path = ORCHESTRATOR_ROOT / "graph_builder.py"
@@ -94,6 +99,15 @@ def test_generator_has_no_node_methods_and_graph_builder_has_no_generator_depend
                 }
                 if parameters & {"generator", "context"}:
                     violations.append(f"{path.name}:{node.name}")
+    routing_path = ORCHESTRATOR_ROOT / "routing.py"
+    routing_tree = ast.parse(routing_path.read_text(encoding="utf-8"))
+    for node in routing_tree.body:
+        if isinstance(node, ast.FunctionDef):
+            parameters = {
+                argument.arg for argument in [*node.args.args, *node.args.kwonlyargs]
+            }
+            if parameters & {"generator", "context"}:
+                violations.append(f"{routing_path.name}:{node.name}")
     assert not violations
 
 

--- a/backend/tests/test_69_04_generator_critic.py
+++ b/backend/tests/test_69_04_generator_critic.py
@@ -191,25 +191,28 @@ class TestImproveSection:
 class TestShouldImproveSections:
     def test_no_improvement_needed(self):
         """GC7a: 所有段落达标时跳过"""
-        from services.blog_generator.generator import BlogGenerator
-        gen = BlogGenerator.__new__(BlogGenerator)
+        from services.blog_generator.orchestrator.routing import (
+            _should_improve_sections,
+        )
         state = {"needs_section_improvement": False}
-        assert gen._should_improve_sections(state) == "continue"
+        assert _should_improve_sections(state) == "continue"
 
     def test_max_rounds_reached(self):
         """GC7b: 达到最大轮数时跳过"""
-        from services.blog_generator.generator import BlogGenerator
-        gen = BlogGenerator.__new__(BlogGenerator)
+        from services.blog_generator.orchestrator.routing import (
+            _should_improve_sections,
+        )
         state = {
             "needs_section_improvement": True,
             "section_improve_count": 2,
         }
-        assert gen._should_improve_sections(state) == "continue"
+        assert _should_improve_sections(state) == "continue"
 
     def test_convergence_detected(self):
         """GC7c: 改进幅度太小时跳过"""
-        from services.blog_generator.generator import BlogGenerator
-        gen = BlogGenerator.__new__(BlogGenerator)
+        from services.blog_generator.orchestrator.routing import (
+            _should_improve_sections,
+        )
         state = {
             "needs_section_improvement": True,
             "section_improve_count": 1,
@@ -219,12 +222,13 @@ class TestShouldImproveSections:
                 {"overall_quality": 6.7},
             ],
         }
-        assert gen._should_improve_sections(state) == "continue"
+        assert _should_improve_sections(state) == "continue"
 
     def test_improvement_needed(self):
         """GC7d: 需要改进时返回 improve"""
-        from services.blog_generator.generator import BlogGenerator
-        gen = BlogGenerator.__new__(BlogGenerator)
+        from services.blog_generator.orchestrator.routing import (
+            _should_improve_sections,
+        )
         state = {
             "needs_section_improvement": True,
             "section_improve_count": 0,
@@ -234,7 +238,7 @@ class TestShouldImproveSections:
                 {"overall_quality": 6.0},
             ],
         }
-        result = gen._should_improve_sections(state)
+        result = _should_improve_sections(state)
         assert result == "improve"
 
 

--- a/backend/tests/test_mini_blog_v2.py
+++ b/backend/tests/test_mini_blog_v2.py
@@ -66,15 +66,16 @@ class TestMiniModeRevisionLimit:
     """测试 Mini 模式修订轮数限制"""
     
     @pytest.fixture
-    def mock_generator(self):
-        """创建 mock 的 BlogGenerator"""
-        from services.blog_generator.generator import BlogGenerator
-        
-        mock_llm = Mock()
-        generator = BlogGenerator(mock_llm)
-        return generator
+    def should_revise(self):
+        from services.blog_generator.orchestrator.routing import (
+            RoutingStyleResolver,
+            _should_revise,
+        )
+
+        resolver = RoutingStyleResolver()
+        return lambda state: _should_revise(state, style_resolver=resolver)
     
-    def test_mini_mode_first_revision_with_high_issues(self, mock_generator):
+    def test_mini_mode_first_revision_with_high_issues(self, should_revise):
         """Mini 模式：第一次修订，有 high 问题 → 应该修订"""
         state = {
             'target_length': 'mini',
@@ -85,14 +86,14 @@ class TestMiniModeRevisionLimit:
             ]
         }
         
-        result = mock_generator._should_revise(state)
+        result = should_revise(state)
         
         assert result == "revision"
         # 验证只保留 high 级别问题
         assert len(state['review_issues']) == 1
         assert state['review_issues'][0]['severity'] == 'high'
     
-    def test_mini_mode_second_revision_skip(self, mock_generator):
+    def test_mini_mode_second_revision_skip(self, should_revise):
         """Mini 模式：已修订 1 轮 → 跳过修订"""
         state = {
             'target_length': 'mini',
@@ -102,11 +103,11 @@ class TestMiniModeRevisionLimit:
             ]
         }
         
-        result = mock_generator._should_revise(state)
+        result = should_revise(state)
         
         assert result == "assemble"
     
-    def test_mini_mode_no_high_issues(self, mock_generator):
+    def test_mini_mode_no_high_issues(self, should_revise):
         """Mini 模式：没有 high 问题 → 跳过修订"""
         state = {
             'target_length': 'mini',
@@ -117,11 +118,11 @@ class TestMiniModeRevisionLimit:
             ]
         }
         
-        result = mock_generator._should_revise(state)
+        result = should_revise(state)
         
         assert result == "assemble"
     
-    def test_short_mode_same_as_mini(self, mock_generator):
+    def test_short_mode_same_as_mini(self, should_revise):
         """Short 模式：与 Mini 模式行为一致"""
         state = {
             'target_length': 'short',
@@ -131,11 +132,11 @@ class TestMiniModeRevisionLimit:
             ]
         }
         
-        result = mock_generator._should_revise(state)
+        result = should_revise(state)
         
         assert result == "assemble"
     
-    def test_medium_mode_allows_multiple_revisions(self, mock_generator):
+    def test_medium_mode_allows_multiple_revisions(self, should_revise):
         """Medium 模式：允许多轮修订"""
         state = {
             'target_length': 'medium',
@@ -146,12 +147,12 @@ class TestMiniModeRevisionLimit:
             ]
         }
         
-        result = mock_generator._should_revise(state)
+        result = should_revise(state)
         
         # medium 模式使用 max_revision_rounds (默认 3)
         assert result == "revision"
     
-    def test_medium_mode_max_revisions_reached(self, mock_generator):
+    def test_medium_mode_max_revisions_reached(self, should_revise):
         """Medium 模式：达到最大修订轮数"""
         state = {
             'target_length': 'medium',
@@ -162,7 +163,7 @@ class TestMiniModeRevisionLimit:
             ]
         }
         
-        result = mock_generator._should_revise(state)
+        result = should_revise(state)
         
         assert result == "assemble"
 

--- a/backend/tests/test_questioner_loop_fix.py
+++ b/backend/tests/test_questioner_loop_fix.py
@@ -49,70 +49,86 @@ class TestStyleProfileMaxQuestioningRounds:
 class TestShouldDeepenUsesStyleProfile:
     """_should_deepen should use StyleProfile.max_questioning_rounds, not hardcoded limit."""
 
-    def _make_generator(self, style=None):
-        """Create a BlogGenerator with mocked dependencies."""
-        from backend.services.blog_generator.style_profile import StyleProfile
-        from backend.services.blog_generator.generator import BlogGenerator
-
-        mock_llm = MagicMock()
-        gen = BlogGenerator(llm_client=mock_llm, style=style or StyleProfile.mini())
-        return gen
-
     def test_mini_stops_after_1_round(self):
         from backend.services.blog_generator.style_profile import StyleProfile
-        gen = self._make_generator(style=StyleProfile.mini())
+        from backend.services.blog_generator.orchestrator.routing import (
+            RoutingStyleResolver,
+            _should_deepen,
+        )
         state = {
             'questioning_count': 1,
             'all_sections_detailed': False,
             'target_length': 'mini',
         }
-        assert gen._should_deepen(state) == "continue"
+        assert _should_deepen(
+            state, style_resolver=RoutingStyleResolver(StyleProfile.mini())
+        ) == "continue"
 
     def test_mini_allows_first_round(self):
         from backend.services.blog_generator.style_profile import StyleProfile
-        gen = self._make_generator(style=StyleProfile.mini())
+        from backend.services.blog_generator.orchestrator.routing import (
+            RoutingStyleResolver,
+            _should_deepen,
+        )
         state = {
             'questioning_count': 0,
             'all_sections_detailed': False,
             'target_length': 'mini',
         }
-        assert gen._should_deepen(state) == "deepen"
+        assert _should_deepen(
+            state, style_resolver=RoutingStyleResolver(StyleProfile.mini())
+        ) == "deepen"
 
     def test_long_allows_up_to_3_rounds(self):
         from backend.services.blog_generator.style_profile import StyleProfile
-        gen = self._make_generator(style=StyleProfile.long())
+        from backend.services.blog_generator.orchestrator.routing import (
+            RoutingStyleResolver,
+            _should_deepen,
+        )
         state = {
             'questioning_count': 2,
             'all_sections_detailed': False,
             'target_length': 'long',
         }
-        assert gen._should_deepen(state) == "deepen"
+        assert _should_deepen(
+            state, style_resolver=RoutingStyleResolver(StyleProfile.long())
+        ) == "deepen"
 
     def test_long_stops_at_3(self):
         from backend.services.blog_generator.style_profile import StyleProfile
-        gen = self._make_generator(style=StyleProfile.long())
+        from backend.services.blog_generator.orchestrator.routing import (
+            RoutingStyleResolver,
+            _should_deepen,
+        )
         state = {
             'questioning_count': 3,
             'all_sections_detailed': False,
             'target_length': 'long',
         }
-        assert gen._should_deepen(state) == "continue"
+        assert _should_deepen(
+            state, style_resolver=RoutingStyleResolver(StyleProfile.long())
+        ) == "continue"
 
     def test_returns_continue_when_all_detailed(self):
         from backend.services.blog_generator.style_profile import StyleProfile
-        gen = self._make_generator(style=StyleProfile.medium())
+        from backend.services.blog_generator.orchestrator.routing import (
+            RoutingStyleResolver,
+            _should_deepen,
+        )
         state = {
             'questioning_count': 0,
             'all_sections_detailed': True,
             'target_length': 'medium',
         }
-        assert gen._should_deepen(state) == "continue"
+        assert _should_deepen(
+            state, style_resolver=RoutingStyleResolver(StyleProfile.medium())
+        ) == "continue"
 
     def test_no_hardcoded_max_deepen_rounds(self):
         """Verify the old MAX_DEEPEN_ROUNDS=5 constant is removed."""
         import inspect
-        from backend.services.blog_generator.generator import BlogGenerator
-        source = inspect.getsource(BlogGenerator._should_deepen)
+        from backend.services.blog_generator.orchestrator.routing import _should_deepen
+        source = inspect.getsource(_should_deepen)
         assert "MAX_DEEPEN_ROUNDS" not in source
 
 

--- a/backend/tests/unit/test_generation_orchestration_contracts.py
+++ b/backend/tests/unit/test_generation_orchestration_contracts.py
@@ -139,6 +139,52 @@ def test_bound_node_dependencies_do_not_retain_generator_instance():
     assert retained_by == []
 
 
+def test_bound_routing_dependencies_do_not_retain_generator_instance():
+    generator = BlogGenerator(MagicMock())
+
+    retained_by = []
+    for routing_name, handler in generator._routing_handlers.items():
+        dependencies = getattr(handler, "keywords", {})
+        for dependency_name, dependency in dependencies.items():
+            if getattr(dependency, "__self__", None) is generator:
+                retained_by.append(f"{routing_name}.{dependency_name}")
+
+    assert retained_by == []
+
+
+def test_bound_routing_handlers_preserve_langgraph_branch_names():
+    generator = BlogGenerator(MagicMock())
+
+    assert {
+        source: set(branches)
+        for source, branches in generator.workflow.branches.items()
+    } == {
+        "writer": {"_should_check_knowledge"},
+        "check_knowledge": {"_should_refine_search"},
+        "questioner": {"_should_deepen"},
+        "deepen_content": {"_should_continue_questioning"},
+        "section_evaluate": {"_should_improve_sections"},
+        "reviewer": {"_should_revise"},
+    }
+
+
+def test_bound_routing_handlers_observe_later_style_updates():
+    from services.blog_generator.style_profile import StyleProfile
+
+    generator = BlogGenerator(MagicMock(), style=StyleProfile.long())
+    handler = generator._routing_handlers["should_deepen"]
+    state = {
+        "target_length": "long",
+        "questioning_count": 1,
+        "all_sections_detailed": False,
+    }
+    assert handler(state) == "deepen"
+
+    generator.style = StyleProfile.mini()
+
+    assert handler(state) == "continue"
+
+
 def test_graph_builder_preserves_workflow_topology():
     node_handlers, routing_handlers, pipeline = _graph_dependencies()
 

--- a/backend/tests/unit/test_routing_policy_functions.py
+++ b/backend/tests/unit/test_routing_policy_functions.py
@@ -1,0 +1,171 @@
+import importlib
+import inspect
+
+import pytest
+
+from services.blog_generator.style_profile import StyleProfile
+
+
+ROUTING_FUNCTIONS = {
+    "_should_check_knowledge",
+    "_should_refine_search",
+    "_should_deepen",
+    "_should_continue_questioning",
+    "_should_improve_sections",
+    "_should_revise",
+}
+
+
+def _routing():
+    return importlib.import_module(
+        "services.blog_generator.orchestrator.routing"
+    )
+
+
+def test_routing_policy_exposes_module_level_functions_with_explicit_dependencies():
+    routing = _routing()
+
+    assert {
+        name for name, value in vars(routing).items()
+        if name in ROUTING_FUNCTIONS and inspect.isfunction(value)
+    } == ROUTING_FUNCTIONS
+    assert list(inspect.signature(
+        routing._should_check_knowledge
+    ).parameters) == ["state"]
+    assert list(inspect.signature(
+        routing._should_improve_sections
+    ).parameters) == ["state"]
+    for name in ROUTING_FUNCTIONS - {
+        "_should_check_knowledge",
+        "_should_improve_sections",
+    }:
+        assert "style_resolver" in inspect.signature(
+            getattr(routing, name)
+        ).parameters
+
+
+@pytest.mark.parametrize(
+    ("state", "expected"),
+    [
+        ({"target_length": "mini"}, "skip"),
+        ({"target_length": "medium"}, "check"),
+        ({}, "check"),
+    ],
+)
+def test_should_check_knowledge_preserves_length_routing(state, expected):
+    assert _routing()._should_check_knowledge(state) == expected
+
+
+def test_should_refine_search_uses_style_and_only_important_gaps():
+    routing = _routing()
+    state = {
+        "target_length": "long",
+        "knowledge_gaps": [{"gap_type": "missing_data"}],
+        "search_count": 0,
+        "max_search_count": 2,
+    }
+
+    assert routing._should_refine_search(
+        state, style_resolver=routing.RoutingStyleResolver()
+    ) == "search"
+    assert routing._should_refine_search(
+        state, style_resolver=routing.RoutingStyleResolver(StyleProfile.mini())
+    ) == "continue"
+    state["knowledge_gaps"] = [{"gap_type": "nice_to_have"}]
+    assert routing._should_refine_search(
+        state, style_resolver=routing.RoutingStyleResolver(StyleProfile.long())
+    ) == "continue"
+
+
+@pytest.mark.parametrize(
+    ("state", "style", "expected"),
+    [
+        (
+            {"questioning_count": 0, "all_sections_detailed": False},
+            StyleProfile.mini(),
+            "deepen",
+        ),
+        (
+            {"questioning_count": 1, "all_sections_detailed": False},
+            StyleProfile.mini(),
+            "continue",
+        ),
+        (
+            {"questioning_count": 0, "all_sections_detailed": True},
+            StyleProfile.long(),
+            "continue",
+        ),
+    ],
+)
+def test_should_deepen_preserves_round_and_detail_rules(state, style, expected):
+    assert _routing()._should_deepen(
+        state, style_resolver=_routing().RoutingStyleResolver(style)
+    ) == expected
+
+
+def test_should_continue_questioning_stops_at_style_limit():
+    routing = _routing()
+
+    assert routing._should_continue_questioning(
+        {"questioning_count": 0},
+        style_resolver=routing.RoutingStyleResolver(StyleProfile.mini()),
+    ) == "questioner"
+    assert routing._should_continue_questioning(
+        {"questioning_count": 1},
+        style_resolver=routing.RoutingStyleResolver(StyleProfile.mini()),
+    ) == "section_evaluate"
+
+
+def test_should_improve_sections_preserves_convergence_state_update():
+    routing = _routing()
+    improving = {
+        "needs_section_improvement": True,
+        "section_improve_count": 0,
+        "prev_section_avg_score": 0,
+        "section_evaluations": [
+            {"overall_quality": 5.0},
+            {"overall_quality": 6.0},
+        ],
+    }
+
+    assert routing._should_improve_sections(improving) == "improve"
+    assert improving["prev_section_avg_score"] == 5.5
+
+    converged = {
+        "needs_section_improvement": True,
+        "section_improve_count": 1,
+        "prev_section_avg_score": 6.5,
+        "section_evaluations": [
+            {"overall_quality": 6.6},
+            {"overall_quality": 6.7},
+        ],
+    }
+    assert routing._should_improve_sections(converged) == "continue"
+    assert converged["prev_section_avg_score"] == 6.5
+
+
+def test_should_revise_preserves_limits_filtering_and_full_review():
+    routing = _routing()
+    high_only = {
+        "revision_count": 0,
+        "review_issues": [
+            {"severity": "high", "description": "critical"},
+            {"severity": "medium", "description": "minor"},
+        ],
+    }
+
+    assert routing._should_revise(
+        high_only,
+        style_resolver=routing.RoutingStyleResolver(StyleProfile.mini()),
+    ) == "revision"
+    assert high_only["review_issues"] == [
+        {"severity": "high", "description": "critical"}
+    ]
+    assert routing._should_revise(
+        {"revision_count": 1, "review_issues": []},
+        style_resolver=routing.RoutingStyleResolver(StyleProfile.mini()),
+    ) == "assemble"
+    assert routing._should_revise(
+        {"revision_count": 0, "review_approved": False},
+        style_resolver=routing.RoutingStyleResolver(StyleProfile.medium()),
+    ) == "revision"


### PR DESCRIPTION
## Summary

- extract all six LangGraph conditional routes into module-level routing policy functions with explicit style resolution
- preserve route return behavior, state mutations, real LangGraph branch identifiers, and post-initialization style updates without retaining the generator instance
- remove the remaining `BlogGenerator._should_*` methods and add architecture/behavior contracts for the new boundary

## Test plan

- `cd backend && python -m pytest tests/ -q` - 1503 passed, 12 skipped
- focused routing/orchestration suite - 83 passed
- `cd backend && PYTHONPATH=. python tests/verify_102_features.py` - 12 passed
- TC02/05/06/09/14 E2E - 12 passed in the combined run; TC14 field completeness saw one external LLM response omit `suggestions`, then passed in an isolated rerun
- `python -m compileall -q services/blog_generator/generator.py services/blog_generator/orchestrator/routing.py`
- `git diff --check`

Part of #159
